### PR TITLE
Fix a couple of race-conditions on shutdown

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -39,7 +39,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
 
   def release
     transaction do
-      job.prepare_for_execution
+      job.dispatch_bypassing_concurrency_limits
       destroy!
     end
   end

--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -33,7 +33,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     else
       failed_with(result.error)
     end
-  ensure
+
     job.unblock_next_blocked_job
   end
 

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -73,6 +73,10 @@ module SolidQueue
         end
       end
 
+      def dispatch_bypassing_concurrency_limits
+        ready
+      end
+
       def finished!
         if preserve_finished_jobs?
           touch(:finished_at)

--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -21,8 +21,5 @@ class SolidQueue::Process < SolidQueue::Record
 
   def deregister
     destroy!
-  rescue Exception
-    SolidQueue.logger.error("[SolidQueue] Error deregistering process #{id} - #{metadata}")
-    raise
   end
 end

--- a/db/migrate/20240110143450_add_missing_index_to_blocked_executions.rb
+++ b/db/migrate/20240110143450_add_missing_index_to_blocked_executions.rb
@@ -1,0 +1,5 @@
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index :solid_queue_blocked_executions, [ :concurrency_key, :priority, :job_id ], name: "index_solid_queue_blocked_executions_for_release"
+  end
+end

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -48,7 +48,7 @@ module SolidQueue::Processes
           run
         end
       end
-    ensure
+
       run_callbacks(:shutdown) { shutdown }
     end
 

--- a/lib/solid_queue/processes/supervised.rb
+++ b/lib/solid_queue/processes/supervised.rb
@@ -31,7 +31,7 @@ module SolidQueue::Processes
         end
 
         trap(:QUIT) do
-          exit!
+          exit
         end
       end
   end

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -163,7 +163,7 @@ module SolidQueue
         if timeout > 0
           deadline = monotonic_time_now + timeout
 
-          while monotonic_time_now < deadline && !condition.call
+          while monotonic_time_now <= deadline && !condition.call
             sleep 0.1
             block.call
           end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_11_200639) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_10_143450) do
   create_table "job_results", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name"
     t.string "status"
@@ -26,6 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_11_200639) do
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
     t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end


### PR DESCRIPTION
This fixes #108 and two other issues I found while working on that one: 
- Only try to release next unblocked job if the job actually completed, either successfully or with a failure, but it needs to have completed. Otherwise, we might be still claimed but signal the semaphore regardless, so it'd be lying about how many jobs are in progress. A good example where this might happen is when the worker is sent a `QUIT` signal to exit right away and the thread pool is killed. As the worker or the supervisor would try to release claimed executions after the shutdown, the claimed execution that holds the semaphore could be potentially blocked because the semaphore is held at least by itself. Then, depending on the order of the thread pool shutting down and the worker being deregistered, we could end up with a job trying to unblock itself and a stuck semaphore.
- ~~Similarly to the above, don't go through the general dispatch flow when releasing claimed executions.  That's it, don't try to gain the concurrency lock, because claimed executions with concurrency limits that are released would most likely be holding the semaphore themselves, as it's released after completing. This means these claimed executions would go to _blocked_ state upon release, leaving the semaphore busy. Just assume that if a job has a claimed execution, it's because it already gained the lock when going to _ready_.~~  Shipped this one separately in #121, with proper tests. 
- Use `exit` instead of `exit!` on immediate termination in runnable processes so that `at_exit` hooks are run if needed.
Besides, remove logging for failing to deregister a process as it just adds noise, and we were re-raising the exception anyway.