### PR TITLE
Stop SolidQueue on puma restart when puma plugin is used.

### DIFF
--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -19,6 +19,7 @@ Puma::Plugin.create do
     end
 
     launcher.events.on_stopped { stop_solid_queue }
+    launcher.events.on_restart { stop_solid_queue }
   end
 
   private


### PR DESCRIPTION
Without doing so SolidQueue would be running making Puma not properly stop so when Puma tries to start its process again we would get `Errno::EADDRINUSE` error.

Closes #180