### PR TITLE
Fix scheduled scope

### DIFF
--- a/app/models/solid_queue/job/schedulable.rb
+++ b/app/models/solid_queue/job/schedulable.rb
@@ -8,7 +8,7 @@ module SolidQueue
       included do
         has_one :scheduled_execution
 
-        scope :scheduled, -> { where.not(finished_at: nil) }
+        scope :scheduled, -> { where(finished_at: nil) }
       end
 
       class_methods do


### PR DESCRIPTION
When looking on a way to compute a queue latency, I was looking for scopes to find jobs that have not run yet.

Looks like `scheduled` is the one, but the implementation seems incorrect. It's actually the same as `finished`.
