### PR TITLE
Used shorthand syntax for hash literals

### DIFF
--- a/app/models/solid_queue/job/clearable.rb
+++ b/app/models/solid_queue/job/clearable.rb
@@ -6,13 +6,13 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        scope :clearable, ->(finished_before: SolidQueue.clear_finished_jobs_after.ago, class_name: nil) { where.not(finished_at: nil).where(finished_at: ...finished_before).where(class_name.present? ? { class_name: class_name } : {}) }
+        scope :clearable, ->(finished_before: SolidQueue.clear_finished_jobs_after.ago, class_name: nil) { where.not(finished_at: nil).where(finished_at: ...finished_before).where(class_name.present? ? { class_name: } : {}) }
       end
 
       class_methods do
         def clear_finished_in_batches(batch_size: 500, finished_before: SolidQueue.clear_finished_jobs_after.ago, class_name: nil)
           loop do
-            records_deleted = clearable(finished_before: finished_before, class_name: class_name).limit(batch_size).delete_all
+            records_deleted = clearable(finished_before:, class_name:).limit(batch_size).delete_all
             break if records_deleted == 0
           end
         end


### PR DESCRIPTION
Ruby 3.1 onwards, we can use shorthand syntax for hash literals. 
Ref: https://github.com/ruby/ruby/commit/c60dbcd1c55cd77a24c41d5e1a9555622be8b2b8