### PR TITLE
Use beginless range for query instead of `< ?`

### DIFF
--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -4,7 +4,7 @@ module SolidQueue::Process::Prunable
   extend ActiveSupport::Concern
 
   included do
-    scope :prunable, -> { where("last_heartbeat_at <= ?", SolidQueue.process_alive_threshold.ago) }
+    scope :prunable, -> { where(last_heartbeat_at: ..SolidQueue.process_alive_threshold.ago) }
   end
 
   class_methods do


### PR DESCRIPTION
This seems a little trivial to suggest (sorry!) but using a range in Rails 7.1 turns the query value into a proper bind parameter and preparable statement. This [will become unnecessary](https://github.com/rails/rails/pull/51139) in the next release of Rails. And I like the beginless/endless queries and all the other queries in SolidQueue that I could find use this style too 👍🏻 

Here's a writeup with a little more info: https://island94.org/2024/03/rails-active-record-will-it-bind