### PR TITLE
Fix the worker count in the generated config file.

### DIFF
--- a/lib/generators/solid_queue/install/templates/config.yml
+++ b/lib/generators/solid_queue/install/templates/config.yml
@@ -4,7 +4,7 @@
 #       batch_size: 500
 #   workers:
 #     - queues: "*"
-#       threads: 5
+#       threads: 3
 #       processes: 1
 #       polling_interval: 0.1
 #


### PR DESCRIPTION
The generated config file still has the worker count of 5, not 3. This led to issues in development as connections were quickly used up causing jobs to be stuck.

I think this was missed as part of #137 