### PR TITLE
fix active support load

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -6,6 +6,9 @@ require "solid_queue/engine"
 require "active_job"
 require "active_job/queue_adapters"
 
+require "active_support"
+require "active_support/core_ext/numeric/time"
+
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)


### PR DESCRIPTION
```
$> bin/rails generate solid_queue:install
/home/solid_queue/lib/solid_queue.rb:26:in `<module:SolidQueue>': undefined method `seconds' for 60:Integer (NoMethodError)
Did you mean?  send
  from /home/solid_queue/lib/solid_queue.rb:20:in `<main>'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler/runtime.rb:55:in `each'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler/runtime.rb:55:in `block in require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler/runtime.rb:44:in `each'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler/runtime.rb:44:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bundler-2.4.18/lib/bundler.rb:187:in `require'
  from /home/credits-api/config/application.rb:21:in `<main>'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command/actions.rb:15:in `require_application!'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command/actions.rb:19:in `boot_application!'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/commands/generate/generate_command.rb:21:in `perform'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command/base.rb:178:in `invoke_command'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command/base.rb:73:in `perform'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command.rb:71:in `block in invoke'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command.rb:149:in `with_argv'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/command.rb:69:in `invoke'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/railties-7.1.3.2/lib/rails/commands.rb:18:in `<main>'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from <internal:/home/.asdf/installs/ruby/3.0.6/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  from /home/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
  from bin/rails:4:in `<main>'
```