### PR TITLE
Rely on `ActiveSupport::Notifications` and `ActiveSupport::LogSubscriber` for logging and instrumentation

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -10,16 +10,18 @@ module SolidQueue
     scope :expired, -> { where(expires_at: ...Time.current) }
 
     class << self
-      def unblock(count)
-        expired.distinct.limit(count).pluck(:concurrency_key).then do |concurrency_keys|
-          release_many releasable(concurrency_keys)
+      def unblock(limit)
+        SolidQueue.instrument(:release_many_blocked, limit: limit) do |payload|
+          expired.distinct.limit(limit).pluck(:concurrency_key).then do |concurrency_keys|
+            payload[:size] = release_many releasable(concurrency_keys)
+          end
         end
       end
 
       def release_many(concurrency_keys)
         # We want to release exactly one blocked execution for each concurrency key, and we need to do it
         # one by one, locking each record and acquiring the semaphore individually for each of them:
-        Array(concurrency_keys).each { |concurrency_key| release_one(concurrency_key) }
+        Array(concurrency_keys).count { |concurrency_key| release_one(concurrency_key) }
       end
 
       def release_one(concurrency_key)
@@ -38,12 +40,14 @@ module SolidQueue
     end
 
     def release
-      transaction do
-        if acquire_concurrency_lock
-          promote_to_ready
-          destroy!
+      SolidQueue.instrument(:release_blocked, job_id: job.id, concurrency_key: concurrency_key, released: false) do |payload|
+        transaction do
+          if acquire_concurrency_lock
+            promote_to_ready
+            destroy!
 
-          SolidQueue.logger.debug("[SolidQueue] Unblocked job #{job.id} under #{concurrency_key}")
+            payload[:released] = true
+          end
         end
       end
     end

--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -26,7 +26,9 @@ module SolidQueue
 
       def release_one(concurrency_key)
         transaction do
-          ordered.where(concurrency_key: concurrency_key).limit(1).non_blocking_lock.each(&:release)
+          if execution = ordered.where(concurrency_key: concurrency_key).limit(1).non_blocking_lock.first
+            execution.release
+          end
         end
       end
 

--- a/app/models/solid_queue/execution.rb
+++ b/app/models/solid_queue/execution.rb
@@ -13,6 +13,10 @@ module SolidQueue
     belongs_to :job
 
     class << self
+      def type
+        model_name.element.sub("_execution", "").to_sym
+      end
+
       def create_all_from_jobs(jobs)
         insert_all execution_data_from_jobs(jobs)
       end
@@ -27,25 +31,32 @@ module SolidQueue
         pending = count
         discarded = 0
 
-        loop do
-          transaction do
-            job_ids = limit(batch_size).order(:job_id).lock.pluck(:job_id)
+        SolidQueue.instrument(:discard_all, batch_size: batch_size, status: type, batches: 0, size: 0) do |payload|
+          loop do
+            transaction do
+              job_ids = limit(batch_size).order(:job_id).lock.pluck(:job_id)
+              discarded = discard_jobs job_ids
 
-            discard_jobs job_ids
-            discarded = where(job_id: job_ids).delete_all
-            pending -= discarded
+              where(job_id: job_ids).delete_all
+              pending -= discarded
+
+              payload[:size] += discarded
+              payload[:batches] += 1
+            end
+
+            break if pending <= 0 || discarded == 0
           end
-
-          break if pending <= 0 || discarded == 0
         end
       end
 
       def discard_all_from_jobs(jobs)
-        transaction do
-          job_ids = lock_all_from_jobs(jobs)
+        SolidQueue.instrument(:discard_all, jobs_size: jobs.size, status: type) do |payload|
+          transaction do
+            job_ids = lock_all_from_jobs(jobs)
 
-          discard_jobs job_ids
-          where(job_id: job_ids).delete_all
+            payload[:size] = discard_jobs job_ids
+            where(job_id: job_ids).delete_all
+          end
         end
       end
 
@@ -59,10 +70,16 @@ module SolidQueue
         end
     end
 
+    def type
+      self.class.type
+    end
+
     def discard
-      with_lock do
-        job.destroy
-        destroy
+      SolidQueue.instrument(:discard, job_id: job_id, status: type) do
+        with_lock do
+          job.destroy
+          destroy
+        end
       end
     end
   end

--- a/app/models/solid_queue/execution/dispatching.rb
+++ b/app/models/solid_queue/execution/dispatching.rb
@@ -9,8 +9,11 @@ module SolidQueue
         def dispatch_jobs(job_ids)
           jobs = Job.where(id: job_ids)
 
-          Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
-            where(job_id: dispatched_job_ids).order(:job_id).delete_all
+          Job.dispatch_all(jobs).map(&:id).then do |dispatched_job_ids|
+            if dispatched_job_ids.none? then 0
+            else
+              where(job_id: dispatched_job_ids).order(:job_id).delete_all
+            end
           end
         end
       end

--- a/app/models/solid_queue/execution/dispatching.rb
+++ b/app/models/solid_queue/execution/dispatching.rb
@@ -11,7 +11,6 @@ module SolidQueue
 
           Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
             where(job_id: dispatched_job_ids).order(:job_id).delete_all
-            SolidQueue.logger.info("[SolidQueue] Dispatched #{dispatched_job_ids.size} jobs")
           end
         end
       end

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -93,7 +93,7 @@ module SolidQueue
         if finished?
           :finished
         elsif execution.present?
-          execution.model_name.element.sub("_execution", "").to_sym
+          execution.type
         end
       end
 

--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -25,7 +25,7 @@ class SolidQueue::Process < SolidQueue::Record
   end
 
   def deregister(pruned: false)
-    SolidQueue.instrument :deregister_process, process: self, pruned: pruned do
+    SolidQueue.instrument :deregister_process, process: self, pruned: pruned, claimed_size: claimed_executions.size do
       destroy!
     end
   rescue Exception => error

--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -25,11 +25,11 @@ class SolidQueue::Process < SolidQueue::Record
   end
 
   def deregister(pruned: false)
-    SolidQueue.instrument :deregister_process, process: self, pruned: pruned, claimed_size: claimed_executions.size do
+    SolidQueue.instrument :deregister_process, process: self, pruned: pruned, claimed_size: claimed_executions.size do |payload|
       destroy!
+    rescue Exception => error
+      payload[:error] = error
+      raise
     end
-  rescue Exception => error
-    SolidQueue.instrument :deregister_process, process: self, error: error
-    raise
   end
 end

--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -9,10 +9,11 @@ module SolidQueue::Process::Prunable
 
   class_methods do
     def prune
-      prunable.non_blocking_lock.find_in_batches(batch_size: 50) do |batch|
-        batch.each do |process|
-          SolidQueue.logger.info("[SolidQueue] Pruning dead process #{process.id} - #{process.metadata}")
-          process.deregister
+      SolidQueue.instrument :prune_processes, size: 0 do |payload|
+        prunable.non_blocking_lock.find_in_batches(batch_size: 50) do |batch|
+          payload[:size] += batch.size
+
+          batch.each { |process| process.deregister(pruned: true) }
         end
       end
     end

--- a/app/models/solid_queue/recurring_execution.rb
+++ b/app/models/solid_queue/recurring_execution.rb
@@ -7,12 +7,12 @@ module SolidQueue
     class << self
       def record(task_key, run_at, &block)
         transaction do
-          if job_id = block.call
-            create!(job_id: job_id, task_key: task_key, run_at: run_at)
+          block.call.tap do |active_job|
+            create!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
           end
         end
       rescue ActiveRecord::RecordNotUnique
-        SolidQueue.logger.info("[SolidQueue] Skipped recurring task #{task_key} at #{run_at} — already dispatched")
+        # Task already dispatched
       end
 
       def clear_in_batches(batch_size: 500)

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -12,12 +12,12 @@ module SolidQueue
 
     class << self
       def dispatch_next_batch(batch_size)
-        SolidQueue.instrument(:dispatch_scheduled, batch_size: batch_size, count: 0) do |payload|
-          transaction do
-            job_ids = next_batch(batch_size).non_blocking_lock.pluck(:job_id)
-            if job_ids.empty? then []
-            else
-              payload[:count] = dispatch_jobs(job_ids)
+        transaction do
+          job_ids = next_batch(batch_size).non_blocking_lock.pluck(:job_id)
+          if job_ids.empty? then []
+          else
+            SolidQueue.instrument(:dispatch_scheduled, batch_size: batch_size) do |payload|
+              payload[:size] = dispatch_jobs(job_ids)
             end
           end
         end

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -18,6 +18,8 @@ loader.ignore("#{__dir__}/puma")
 loader.setup
 
 module SolidQueue
+  extend self
+
   mattr_accessor :logger, default: ActiveSupport::Logger.new($stdout)
   mattr_accessor :app_executor, :on_thread_error, :connects_to
 
@@ -39,17 +41,19 @@ module SolidQueue
   mattr_accessor :clear_finished_jobs_after, default: 1.day
   mattr_accessor :default_concurrency_control_period, default: 3.minutes
 
-  class << self
-    def supervisor?
-      supervisor
-    end
+  def supervisor?
+    supervisor
+  end
 
-    def silence_polling?
-      silence_polling
-    end
+  def silence_polling?
+    silence_polling
+  end
 
-    def preserve_finished_jobs?
-      preserve_finished_jobs
-    end
+  def preserve_finished_jobs?
+    preserve_finished_jobs
+  end
+
+  def instrument(channel, **options, &block)
+    ActiveSupport::Notifications.instrument("#{channel}.solid_queue", **options, &block)
   end
 end

--- a/lib/solid_queue/app_executor.rb
+++ b/lib/solid_queue/app_executor.rb
@@ -11,7 +11,7 @@ module SolidQueue
     end
 
     def handle_thread_error(error)
-      SolidQueue.logger.error("[SolidQueue] #{error}")
+      SolidQueue.instrument(:thread_error, error: error)
 
       if SolidQueue.on_thread_error
         SolidQueue.on_thread_error.call(error)

--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -19,6 +19,10 @@ module SolidQueue
       @recurring_schedule = RecurringSchedule.new(options[:recurring_tasks])
     end
 
+    def metadata
+      super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval, recurring_schedule: recurring_schedule.tasks.presence)
+    end
+
     private
       def poll
         batch = dispatch_next_batch
@@ -49,10 +53,6 @@ module SolidQueue
 
       def set_procline
         procline "waiting"
-      end
-
-      def metadata
-        super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval, recurring_schedule: recurring_schedule.tasks.presence)
       end
   end
 end

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -27,6 +27,7 @@ module SolidQueue
     initializer "solid_queue.logger" do |app|
       ActiveSupport.on_load(:solid_queue) do
         self.logger = app.logger
+        SolidQueue::LogSubscriber.logger = self.logger
       end
 
       SolidQueue::LogSubscriber.attach_to :solid_queue

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -26,8 +26,7 @@ module SolidQueue
 
     initializer "solid_queue.logger" do |app|
       ActiveSupport.on_load(:solid_queue) do
-        self.logger = app.logger
-        SolidQueue::LogSubscriber.logger = self.logger
+        self.logger ||= app.logger
       end
 
       SolidQueue::LogSubscriber.attach_to :solid_queue

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -28,6 +28,8 @@ module SolidQueue
       ActiveSupport.on_load(:solid_queue) do
         self.logger = app.logger
       end
+
+      SolidQueue::LogSubscriber.attach_to :solid_queue
     end
 
     initializer "solid_queue.active_job.extensions" do

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -23,6 +23,14 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     debug formatted_event(event, action: "Retry failed job", **event.payload.slice(:job_id))
   end
 
+  def discard_all(event)
+    debug formatted_event(event, action: "Discard jobs", **event.payload.slice(:jobs_size, :size, :status))
+  end
+
+  def discard(event)
+    debug formatted_event(event, action: "Discard job", **event.payload.slice(:job_id, :status))
+  end
+
   def release_many_blocked(event)
     debug formatted_event(event, action: "Unblock jobs", **event.payload.slice(:limit, :size))
   end

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "active_support/log_subscriber"
+
+class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
+  def release_many_blocked(event)
+    debug formatted_event(event, action: "Unblock jobs", **event.payload.slice(:limit, :size))
+  end
+
+  def release_blocked(event)
+    debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
+  end
+
+  def release_many_claimed(event)
+    debug formatted_event(event, action: "Release claimed jobs", **event.payload.slice(:size))
+  end
+
+  def release_claimed(event)
+    debug formatted_event(event, action: "Release claimed job", **event.payload.slice(:job_id, :process_id))
+  end
+
+  def dispatch_scheduled(event)
+    debug formatted_event(event, action: "Dispatch scheduled jobs", **event.payload.slice(:batch_size, :size))
+  end
+
+  def retry_all(event)
+    debug formatted_event(event, action: "Retry failed jobs", **event.payload.slice(:jobs_size, :size))
+  end
+
+  def retry(event)
+    debug formatted_event(event, action: "Retry failed job", **event.payload.slice(:job_id))
+  end
+
+  def register_process(event)
+    attributes = event.payload.slice(:kind, :pid, :hostname)
+
+    if error = event.payload[:error]
+      warn formatted_event(event, action: "Error registering process", **attributes.merge(error: formatted_error(error)))
+    else
+      info formatted_event(event, action: "Register process", **attributes)
+    end
+  end
+
+  def deregister_process(event)
+    process = event.payload[:process]
+
+    attributes = {
+      process_id: process.id,
+      pid: process.pid,
+      kind: process.kind,
+      hostname: process.hostname,
+      last_heartbeat_at: process.last_heartbeat_at,
+      claimed_size: process.claimed_executions.size,
+      pruned: event.payload
+    }
+
+    if error = event.payload[:error]
+      warn formatted_event(event, action: "Error deregistering process", **attributes.merge(formatted_error(error)))
+    else
+      info formatted_event(event, action: "Deregister process", **attributes)
+    end
+  end
+
+  def prune_processes(event)
+    debug formatted_event(event, action: "Prune dead processes", **event.payload.slice(:size))
+  end
+
+  private
+    def formatted_event(event, action:, **attributes)
+      "SolidQueue-#{SolidQueue::VERSION} #{action} (#{event.duration.round(1)}ms)  #{formatted_attributes(**attributes)}"
+    end
+
+    def formatted_attributes(**attributes)
+      attributes.map { |attr, value| "#{attr}: #{value.inspect}" }.join(", ")
+    end
+
+    def formatted_error(error)
+      [ error.class, error.message ].compact.join(" ")
+    end
+end

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -39,6 +39,17 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
   end
 
+  def enqueue_recurring_task(event)
+    attributes = event.payload.slice(:task, :at, :active_job_id)
+
+    if event.payload[:other_adapter]
+      debug formatted_event(event, action: "Enqueued recurring task outside Solid Queue", **attributes)
+    else
+      action = attributes[:active_job_id].present? ? "Enqueued recurring task" : "Skipped recurring task – already dispatched"
+      info formatted_event(event, action: action, **attributes)
+    end
+  end
+
   def register_process(event)
     attributes = event.payload.slice(:kind, :pid, :hostname)
 

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -3,12 +3,8 @@
 require "active_support/log_subscriber"
 
 class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
-  def release_many_blocked(event)
-    debug formatted_event(event, action: "Unblock jobs", **event.payload.slice(:limit, :size))
-  end
-
-  def release_blocked(event)
-    debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
+  def dispatch_scheduled(event)
+    debug formatted_event(event, action: "Dispatch scheduled jobs", **event.payload.slice(:batch_size, :size))
   end
 
   def release_many_claimed(event)
@@ -19,16 +15,20 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     debug formatted_event(event, action: "Release claimed job", **event.payload.slice(:job_id, :process_id))
   end
 
-  def dispatch_scheduled(event)
-    debug formatted_event(event, action: "Dispatch scheduled jobs", **event.payload.slice(:batch_size, :size))
-  end
-
   def retry_all(event)
     debug formatted_event(event, action: "Retry failed jobs", **event.payload.slice(:jobs_size, :size))
   end
 
   def retry(event)
     debug formatted_event(event, action: "Retry failed job", **event.payload.slice(:job_id))
+  end
+
+  def release_many_blocked(event)
+    debug formatted_event(event, action: "Unblock jobs", **event.payload.slice(:limit, :size))
+  end
+
+  def release_blocked(event)
+    debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
   end
 
   def register_process(event)

--- a/lib/solid_queue/processes/base.rb
+++ b/lib/solid_queue/processes/base.rb
@@ -5,6 +5,22 @@ module SolidQueue
     class Base
       include Callbacks # Defines callbacks needed by other concerns
       include AppExecutor, Registrable, Interruptible, Procline
+
+      def kind
+        self.class.name.demodulize
+      end
+
+      def hostname
+        @hostname ||= Socket.gethostname.force_encoding(Encoding::UTF_8)
+      end
+
+      def pid
+        @pid ||= ::Process.pid
+      end
+
+      def metadata
+        {}
+      end
     end
   end
 end

--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -10,6 +10,10 @@ module SolidQueue::Processes
       attr_accessor :polling_interval
     end
 
+    def metadata
+      super.merge(polling_interval: polling_interval)
+    end
+
     private
       def run
         if mode.async?
@@ -43,10 +47,6 @@ module SolidQueue::Processes
         else
           yield
         end
-      end
-
-      def metadata
-        super.merge(polling_interval: polling_interval)
       end
   end
 end

--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -34,7 +34,9 @@ module SolidQueue::Processes
           end
         end
       ensure
-        run_callbacks(:shutdown) { shutdown }
+        SolidQueue.instrument(:shutdown_process, process: self) do
+          run_callbacks(:shutdown) { shutdown }
+        end
       end
 
       def poll

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -11,18 +11,13 @@ module SolidQueue::Processes
       after_shutdown :deregister
     end
 
-    def inspect
-      "#{kind}(pid=#{process_pid}, hostname=#{hostname}, metadata=#{metadata})"
-    end
-    alias to_s inspect
-
     private
       attr_accessor :process
 
       def register
         @process = SolidQueue::Process.register \
           kind: self.class.name.demodulize,
-          pid: process_pid,
+          pid: pid,
           hostname: hostname,
           supervisor: try(:supervisor),
           metadata: metadata.compact
@@ -47,22 +42,6 @@ module SolidQueue::Processes
 
       def heartbeat
         process.heartbeat
-      end
-
-      def kind
-        self.class.name.demodulize
-      end
-
-      def hostname
-        @hostname ||= Socket.gethostname.force_encoding(Encoding::UTF_8)
-      end
-
-      def process_pid
-        @pid ||= ::Process.pid
-      end
-
-      def metadata
-        {}
       end
   end
 end

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -8,7 +8,10 @@ module SolidQueue::Processes
 
     def start
       @stopping = false
-      run_callbacks(:boot) { boot }
+
+      SolidQueue.instrument(:start_process, process: self) do
+        run_callbacks(:boot) { boot }
+      end
 
       run
     end
@@ -30,8 +33,6 @@ module SolidQueue::Processes
           register_signal_handlers
           set_procline
         end
-
-        SolidQueue.logger.info("[SolidQueue] Starting #{self}")
       end
 
       def shutting_down?

--- a/lib/solid_queue/processes/signals.rb
+++ b/lib/solid_queue/processes/signals.rb
@@ -38,7 +38,7 @@ module SolidQueue::Processes
         when :QUIT
           request_immediate_termination
         else
-          SolidQueue.logger.warn "Received unhandled signal #{signal}"
+          SolidQueue.instrument :unhandled_signal_error, signal: signal
         end
       end
 

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -152,11 +152,11 @@ module SolidQueue
       end
 
       def replace_fork(pid, status)
-        if supervised_fork = forks.delete(pid)
-          SolidQueue.logger.info "[SolidQueue] Restarting fork[#{status.pid}] (status: #{status.exitstatus})"
-          start_fork(supervised_fork)
-        else
-          SolidQueue.logger.info "[SolidQueue] Tried to replace fork[#{pid}] (status: #{status.exitstatus}, fork[#{status.pid}]), but it had already died  (status: #{status.exitstatus})"
+        SolidQueue.instrument(:replace_fork, supervisor_pid: ::Process.pid, pid: pid, status: status) do |payload|
+          if supervised_fork = forks.delete(pid)
+            payload[:fork] = supervised_fork
+            start_fork(supervised_fork)
+          end
         end
       end
 

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -32,10 +32,10 @@ module SolidQueue
       end
 
       def shutdown
-        super
-
         pool.shutdown
         pool.wait_for_termination(SolidQueue.shutdown_timeout)
+
+        super
       end
 
       def all_work_completed?

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -14,6 +14,10 @@ module SolidQueue
       @pool = Pool.new(options[:threads], on_idle: -> { wake_up })
     end
 
+    def metadata
+      super.merge(queues: queues.join(","), thread_pool_size: pool.size)
+    end
+
     private
       def poll
         claim_executions.then do |executions|
@@ -44,10 +48,6 @@ module SolidQueue
 
       def set_procline
         procline "waiting for jobs in #{queues.join(",")}"
-      end
-
-      def metadata
-        super.merge(queues: queues.join(","), thread_pool_size: pool.size)
       end
   end
 end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InstrumentationTest < ActiveSupport::TestCase
+  test "dispatcher polling emits dispatch_scheduled event" do
+    8.times { AddToBufferJob.set(wait: 1.day).perform_later("I'm scheduled") }
+
+    events = subscribed("dispatch_scheduled.solid_queue") do
+      travel_to 2.days.from_now
+      dispatcher = SolidQueue::Dispatcher.new(polling_interval: 0.1, batch_size: 10).tap(&:start)
+
+      wait_while_with_timeout(0.5.seconds) { SolidQueue::ScheduledExecution.any? }
+      dispatcher.stop
+    end
+
+    assert_equal 1, events.size
+    assert_event events.first, "dispatch_scheduled", batch_size: 10, size: 8
+  end
+
+  test "stopping a worker with claimed executions emits release_claimed events" do
+    StoreResultJob.perform_later(42, pause: SolidQueue.shutdown_timeout + 10.second)
+    process = nil
+
+    events = subscribed(/release.*_claimed\.solid_queue/) do
+      worker = SolidQueue::Worker.new.tap(&:start)
+
+      wait_while_with_timeout(0.5.seconds) { SolidQueue::ReadyExecution.any? }
+      process = SolidQueue::Process.last
+
+      worker.stop
+    end
+
+    assert_equal 2, events.size
+    release_one_event, release_many_event = events
+    assert_event release_one_event, "release_claimed", job_id: SolidQueue::Job.last.id, process_id: process.id
+    assert_event release_many_event, "release_many_claimed", size: 1
+  end
+
+  test "starting and stopping a worker emits register_process and deregister_process events" do
+    process = nil
+
+    events = subscribed(/(register|deregister)_process\.solid_queue/) do
+      worker = SolidQueue::Worker.new.tap(&:start)
+      wait_for_registered_processes(1, timeout: 1.second)
+
+      process = SolidQueue::Process.last
+
+      worker.stop
+      wait_for_registered_processes(0, timeout: 1.second)
+    end
+
+    assert_equal 2, events.size
+    register_event, deregister_event = events
+
+    assert_event register_event, "register_process", kind: "Worker", pid: ::Process.pid
+    assert_event deregister_event, "deregister_process", process: process, pruned: false
+  end
+
+  test "pruning processes emit prune_processes and deregister_process events" do
+    time = Time.now
+    processes = 3.times.collect { |i| SolidQueue::Process.create!(kind: "Worker", supervisor_id: 42, pid: 10 + i, hostname: "localhost", last_heartbeat_at: time) }
+
+    # Heartbeats will expire
+    travel_to 3.days.from_now
+
+    events = subscribed(/.*process.*\.solid_queue/) do
+      SolidQueue::Process.prune
+    end
+
+    # 1 prune event + 3 deregister events
+    assert_equal 4, events.count
+    deregister_events = events.first(3)
+    prune_event = events.last
+
+    assert_event prune_event, "prune_processes", size: 3
+    deregister_events.each_with_index do |event, i|
+      assert_event event, "deregister_process", process: processes[i], pruned: true
+    end
+  end
+
+  test "retrying failed job emits retry event" do
+    RaisingJob.perform_later(RuntimeError, "A")
+    job = SolidQueue::Job.last
+
+    worker = SolidQueue::Worker.new.tap(&:start)
+    wait_for_jobs_to_finish_for(3.seconds)
+    worker.stop
+
+    events = subscribed("retry.solid_queue") do
+      job.reload.retry
+    end
+
+    assert_equal 1, events.size
+    assert_event events.first, "retry", job_id: job.id
+  end
+
+  test "retrying failed jobs in bulk emits retry_all" do
+    3.times { RaisingJob.perform_later(RuntimeError, "A") }
+    AddToBufferJob.perform_later("A")
+
+    jobs = SolidQueue::Job.last(4)
+
+    worker = SolidQueue::Worker.new.tap(&:start)
+    wait_for_jobs_to_finish_for(3.seconds)
+    worker.stop
+
+    events = subscribed("retry_all.solid_queue") do
+      SolidQueue::FailedExecution.retry_all(jobs)
+      SolidQueue::FailedExecution.retry_all(jobs)
+    end
+
+    assert_equal 2, events.size
+    assert_event events.first, "retry_all", jobs_size: 4, size: 3
+    assert_event events.second, "retry_all", jobs_size: 4, size: 0
+  end
+
+  test "unblocking job emits release_blocked event" do
+    result = JobResult.create!
+    # 1 ready, 2 blocked
+    3.times { SequentialUpdateResultJob.perform_later(result, name: name, pause: 0.2.seconds) }
+
+    # Simulate expiry of the concurrency locks
+    travel_to 3.days.from_now
+    SolidQueue::Semaphore.expired.delete_all
+
+    blocked_jobs = SolidQueue::BlockedExecution.last(2).map(&:job)
+    concurrency_key = blocked_jobs.first.concurrency_key
+
+    events = subscribed("release_blocked.solid_queue") do
+      SolidQueue::BlockedExecution.release_one(concurrency_key)
+      SolidQueue::BlockedExecution.release_one(concurrency_key)
+    end
+
+    assert_equal 2, events.size
+    assert_event events.first, "release_blocked", job_id: blocked_jobs.first.id, concurrency_key: concurrency_key, released: true
+    assert_event events.second, "release_blocked", job_id: blocked_jobs.second.id, concurrency_key: concurrency_key, released: false
+  end
+
+  test "unblocking jobs in bulk emits release_many_blocked event" do
+    result = JobResult.create!
+    # 1 ready, 3 blocked
+    4.times { SequentialUpdateResultJob.perform_later(result, name: name, pause: 0.2.seconds) }
+
+    # Simulate expiry of the concurrency locks
+    travel_to 3.days.from_now
+    SolidQueue::Semaphore.expired.delete_all
+
+    events = subscribed("release_many_blocked.solid_queue") do
+      SolidQueue::BlockedExecution.unblock(5)
+      SolidQueue::BlockedExecution.unblock(5)
+    end
+
+    assert_equal 2, events.size
+    assert_event events.first, "release_many_blocked", limit: 5, size: 1
+    assert_event events.second, "release_many_blocked", limit: 5, size: 0
+  end
+
+  private
+    def subscribed(name, &block)
+      [].tap do |events|
+        ActiveSupport::Notifications.subscribed(->(*args) { events << args }, name, &block)
+      end
+    end
+
+    def assert_event(event, action, **attributes)
+      assert_equal "#{action}.solid_queue", event.first
+      assert_equal attributes, event.last.slice(*attributes.keys)
+    end
+end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -25,11 +25,11 @@ class InstrumentationTest < ActiveSupport::TestCase
     events = subscribed(/release.*_claimed\.solid_queue/) do
       worker = SolidQueue::Worker.new.tap(&:start)
 
-      wait_while_with_timeout(1.seconds) { SolidQueue::ReadyExecution.any? }
+      wait_while_with_timeout(3.seconds) { SolidQueue::ReadyExecution.any? }
       process = SolidQueue::Process.last
 
       worker.stop
-      wait_for_registered_processes(0, timeout: 1.second)
+      wait_for_registered_processes(0, timeout: 3.second)
     end
 
     assert_equal 2, events.size
@@ -59,12 +59,12 @@ class InstrumentationTest < ActiveSupport::TestCase
 
     events = subscribed(/(register|deregister)_process\.solid_queue/) do
       worker = SolidQueue::Worker.new.tap(&:start)
-      wait_while_with_timeout(1.seconds) { SolidQueue::ReadyExecution.any? }
+      wait_while_with_timeout(3.seconds) { SolidQueue::ReadyExecution.any? }
 
       process = SolidQueue::Process.last
 
       worker.stop
-      wait_for_registered_processes(0, timeout: 1.second)
+      wait_for_registered_processes(0, timeout: 3.second)
     end
 
     assert_equal 2, events.size

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -220,6 +220,10 @@ class InstrumentationTest < ActiveSupport::TestCase
     # 1 ready, 3 blocked
     4.times { SequentialUpdateResultJob.perform_later(result, name: "A") }
 
+    # 1 ready, 2 blocked
+    result = JobResult.create!
+    3.times { SequentialUpdateResultJob.perform_later(result, name: "B") }
+
     # Simulate expiry of the concurrency locks
     travel_to 3.days.from_now
     SolidQueue::Semaphore.expired.delete_all
@@ -230,7 +234,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     end
 
     assert_equal 2, events.size
-    assert_event events.first, "release_many_blocked", limit: 5, size: 1
+    assert_event events.first, "release_many_blocked", limit: 5, size: 2
     assert_event events.second, "release_many_blocked", limit: 5, size: 0
   end
 

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -211,7 +211,7 @@ class ProcessLifecycleTest < ActiveSupport::TestCase
     end
 
     def assert_no_registered_workers
-      assert_empty find_processes_registered_as("Worker")
+      assert_empty find_processes_registered_as("Worker").to_a
     end
 
     def enqueue_store_result_job(value, queue_name = :background, count = 1, **options)

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -8,6 +8,10 @@ class LogSubscriberTest < ActiveSupport::TestCase
 
   teardown { ActiveSupport::LogSubscriber.log_subscribers.clear }
 
+  def set_logger(logger)
+    SolidQueue.logger = logger
+  end
+
   test "unblock one job" do
     attach_log_subscriber
     instrument "release_blocked.solid_queue", job_id: 42, concurrency_key: "foo/1", released: true

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -17,9 +17,9 @@ class LogSubscriberTest < ActiveSupport::TestCase
 
   test "unblock many jobs" do
     attach_log_subscriber
-    instrument "unblock_batch.solid_queue", batch_size: 42
+    instrument "release_many_blocked.solid_queue", limit: 42, size: 10
 
-    assert_match_logged :debug, "Unblock jobs", "batch_size: 42"
+    assert_match_logged :debug, "Unblock jobs", "limit: 42, size: 10"
   end
 
   private

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_support/log_subscriber/test_helper"
+
+class LogSubscriberTest < ActiveSupport::TestCase
+  include ActiveSupport::LogSubscriber::TestHelper
+
+  teardown { ActiveSupport::LogSubscriber.log_subscribers.clear }
+
+  test "unblock one job" do
+    attach_log_subscriber
+    instrument "release_blocked.solid_queue", job_id: 42, concurrency_key: "foo/1", released: true
+
+    assert_match_logged :debug, "Release blocked job", "job_id: 42, concurrency_key: \"foo/1\", released: true"
+  end
+
+  test "unblock many jobs" do
+    attach_log_subscriber
+    instrument "unblock_batch.solid_queue", batch_size: 42
+
+    assert_match_logged :debug, "Unblock jobs", "batch_size: 42"
+  end
+
+  private
+    def attach_log_subscriber
+      ActiveSupport::LogSubscriber.attach_to :solid_queue, SolidQueue::LogSubscriber.new
+    end
+
+    def instrument(...)
+      ActiveSupport::Notifications.instrument(...)
+      wait
+    end
+
+    def assert_match_logged(level, action, attributes)
+      assert_equal 1, @logger.logged(level).size
+      assert_match /SolidQueue-[\d.]+ #{action} \(\d+\.\d+ms\)  #{Regexp.escape(attributes)}/, @logger.logged(level).last
+    end
+end


### PR DESCRIPTION
This includes the basics to make it work, plus instrumentation for the most relevant actions. 

Closes #103.