### PR TITLE
Added enqueue_after_transaction_commit setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ There are several settings that control how Solid Queue works that you can set a
 - `preserve_finished_jobs`: whether to keep finished jobs in the `solid_queue_jobs` table—defaults to `true`.
 - `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true—defaults to 1 day. **Note:** Right now, there's no automatic cleanup of finished jobs. You'd need to do this by periodically invoking `SolidQueue::Job.clear_finished_in_batches`, but this will happen automatically in the near future.
 - `default_concurrency_control_period`: the value to be used as the default for the `duration` parameter in [concurrency controls](#concurrency-controls). It defaults to 3 minutes.
+- `enqueue_after_transaction_commit`: it defines weather the job should be enqueued after `after_commit`. [Read more](https://github.com/rails/rails/pull/51426) about it.
 
 
 ## Concurrency controls

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ There are several settings that control how Solid Queue works that you can set a
 - `preserve_finished_jobs`: whether to keep finished jobs in the `solid_queue_jobs` table—defaults to `true`.
 - `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true—defaults to 1 day. **Note:** Right now, there's no automatic cleanup of finished jobs. You'd need to do this by periodically invoking `SolidQueue::Job.clear_finished_in_batches`, but this will happen automatically in the near future.
 - `default_concurrency_control_period`: the value to be used as the default for the `duration` parameter in [concurrency controls](#concurrency-controls). It defaults to 3 minutes.
-- `enqueue_after_transaction_commit`: it defines whether the job should be enqueued after `after_commit`. [Read more](https://github.com/rails/rails/pull/51426) about it.
+- `enqueue_after_transaction_commit`: it defines whether the job should be enqueued after `after_commit`. The default is `true`. [Read more](https://github.com/rails/rails/pull/51426) about it.
 
 
 ## Concurrency controls

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ There are several settings that control how Solid Queue works that you can set a
 - `preserve_finished_jobs`: whether to keep finished jobs in the `solid_queue_jobs` table—defaults to `true`.
 - `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true—defaults to 1 day. **Note:** Right now, there's no automatic cleanup of finished jobs. You'd need to do this by periodically invoking `SolidQueue::Job.clear_finished_in_batches`, but this will happen automatically in the near future.
 - `default_concurrency_control_period`: the value to be used as the default for the `duration` parameter in [concurrency controls](#concurrency-controls). It defaults to 3 minutes.
-- `enqueue_after_transaction_commit`: it defines weather the job should be enqueued after `after_commit`. [Read more](https://github.com/rails/rails/pull/51426) about it.
+- `enqueue_after_transaction_commit`: it defines whether the job should be enqueued after `after_commit`. [Read more](https://github.com/rails/rails/pull/51426) about it.
 
 
 ## Concurrency controls

--- a/lib/active_job/queue_adapters/solid_queue_adapter.rb
+++ b/lib/active_job/queue_adapters/solid_queue_adapter.rb
@@ -8,6 +8,10 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :solid_queue
     class SolidQueueAdapter
+      def enqueue_after_transaction_commit?
+        SolidQueue.enqueue_after_transaction_commit
+      end
+
       def enqueue(active_job) # :nodoc:
         SolidQueue::Job.enqueue(active_job)
       end

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -28,7 +28,7 @@ module SolidQueue
 
   mattr_accessor :shutdown_timeout, default: 5.seconds
 
-  mattr_accessor :enqueue_after_transaction_commit, default: false
+  mattr_accessor :enqueue_after_transaction_commit, default: true
 
   mattr_accessor :silence_polling, default: true
 

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -28,6 +28,8 @@ module SolidQueue
 
   mattr_accessor :shutdown_timeout, default: 5.seconds
 
+  mattr_accessor :enqueue_after_transaction_commit, default: false
+
   mattr_accessor :silence_polling, default: true
 
   mattr_accessor :supervisor_pidfile


### PR DESCRIPTION
The `enqueue_after_transaction_commit` method was recently added to ActiveJob to be supported by the adapters.
PR: https://github.com/rails/rails/pull/51426