### PR TITLE
Set `enqueue_after_transaction_commit` to `false` by default

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -28,7 +28,7 @@ module SolidQueue
 
   mattr_accessor :shutdown_timeout, default: 5.seconds
 
-  mattr_accessor :enqueue_after_transaction_commit, default: true
+  mattr_accessor :enqueue_after_transaction_commit, default: false
 
   mattr_accessor :silence_polling, default: true
 


### PR DESCRIPTION
After some great points raised on #212, and the suggestion given by the same Rails guides. This was the original value set in #209, that was changed as I suggested it 😅 .