### PR TITLE
Support multiple databases for install generator

### DIFF
--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -4,6 +4,7 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path("templates", __dir__)
 
   class_option :skip_migrations, type: :boolean, default: nil, desc: "Skip migrations"
+  class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
   def add_solid_queue
     if (env_config = Pathname(destination_root).join("config/environments/production.rb")).exist?
@@ -15,7 +16,7 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
 
   def create_migrations
     unless options[:skip_migrations]
-      rails_command "railties:install:migrations FROM=solid_queue", inline: true
+      rails_command "railties:install:migrations FROM=solid_queue DATABASE=#{options[:database]}", inline: true
     end
   end
 end


### PR DESCRIPTION
Currently, there is no way to specify that the migration files be installed into a separate database from the default. This is problematic especially for SQLite apps, since the recommended approach is to use a separate SQLite database for the queue. 

This change supports the existing behavior as well as specifying the `--database` option or the `--db` option.