### PR TITLE
Handle case of concurrency limit not being set in Semaphore

### DIFF
--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -70,7 +70,7 @@ module SolidQueue
         end
 
         def limit
-          job.concurrency_limit
+          job.concurrency_limit || 1
         end
     end
   end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -19,7 +19,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "stopping a worker with claimed executions emits release_claimed events" do
-    StoreResultJob.perform_later(42, pause: SolidQueue.shutdown_timeout + 10.second)
+    StoreResultJob.perform_later(42, pause: SolidQueue.shutdown_timeout + 100.second)
     process = nil
 
     events = subscribed(/release.*_claimed\.solid_queue/) do
@@ -54,7 +54,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "starting and stopping a worker emits register_process and deregister_process events" do
-    StoreResultJob.perform_later(42, pause: SolidQueue.shutdown_timeout + 10.second)
+    StoreResultJob.perform_later(42, pause: SolidQueue.shutdown_timeout + 100.second)
     process = nil
 
     events = subscribed(/(register|deregister)_process\.solid_queue/) do

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -10,7 +10,7 @@ class InstrumentationTest < ActiveSupport::TestCase
       travel_to 2.days.from_now
       dispatcher = SolidQueue::Dispatcher.new(polling_interval: 0.1, batch_size: 10).tap(&:start)
 
-      wait_while_with_timeout(0.5.seconds) { SolidQueue::ScheduledExecution.any? }
+      wait_while_with_timeout!(0.5.seconds) { SolidQueue::ScheduledExecution.any? }
       dispatcher.stop
     end
 
@@ -25,7 +25,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     events = subscribed(/release.*_claimed\.solid_queue/) do
       worker = SolidQueue::Worker.new.tap(&:start)
 
-      wait_while_with_timeout(3.seconds) { SolidQueue::ReadyExecution.any? }
+      wait_while_with_timeout!(3.seconds) { SolidQueue::ReadyExecution.any? }
       process = SolidQueue::Process.last
 
       worker.stop
@@ -59,7 +59,7 @@ class InstrumentationTest < ActiveSupport::TestCase
 
     events = subscribed(/(register|deregister)_process\.solid_queue/) do
       worker = SolidQueue::Worker.new.tap(&:start)
-      wait_while_with_timeout(3.seconds) { SolidQueue::ReadyExecution.any? }
+      wait_while_with_timeout!(3.seconds) { SolidQueue::ReadyExecution.any? }
 
       process = SolidQueue::Process.last
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,11 @@ class ActiveSupport::TestCase
     end
 
     def wait_while_with_timeout(timeout, &block)
+      wait_while_with_timeout!(timeout, &block)
+    rescue Timeout::Error
+    end
+
+    def wait_while_with_timeout!(timeout, &block)
       Timeout.timeout(timeout) do
         skip_active_record_query_cache do
           while block.call
@@ -92,7 +97,6 @@ class ActiveSupport::TestCase
           end
         end
       end
-    rescue Timeout::Error
     end
 
     def signal_process(pid, signal, wait: nil)


### PR DESCRIPTION
Avoid crashing in this case, just assume concurrency limit is 1. This shouldn't happen with normal operation but we've had this problem when jobs that are concurrency-limited are enqueued from new code and dispatched from old code, where the job still doesn't have concurrency controls, thus returning `nil` for the limit and crashing the dispatcher. 