### PR TITLE
Launch process prune from supervisor after forking supervised processes 

### DIFF
--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -32,7 +32,10 @@ module SolidQueue::Processes
       end
 
       def launch_heartbeat
-        @heartbeat_task = Concurrent::TimerTask.new(execution_interval: SolidQueue.process_heartbeat_interval) { heartbeat }
+        @heartbeat_task = Concurrent::TimerTask.new(execution_interval: SolidQueue.process_heartbeat_interval) do
+          wrap_in_app_executor { heartbeat }
+        end
+
         @heartbeat_task.execute
       end
 

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -66,7 +66,7 @@ module SolidQueue
       end
 
       def launch_process_prune
-        @prune_task = Concurrent::TimerTask.new(run_now: true, execution_interval: 2.seconds) { prune_dead_processes }
+        @prune_task = Concurrent::TimerTask.new(run_now: true, execution_interval: SolidQueue.process_alive_threshold) { prune_dead_processes }
         @prune_task.execute
       end
 


### PR DESCRIPTION
Otherwise, the process prune thread seems to interfere with each forks' threads reloading, [making them come to a halt](https://github.com/rails/solid_queue/issues/204) when code is changed and they need to reload one at a time.