### PR TITLE
Fixes #224.  I believe this is a Postgres only issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -66,11 +66,11 @@ module SolidQueue
         def check_limit_or_decrement = limit == 1 ? false : attempt_decrement
 
         def attempt_decrement
-          Semaphore.available.where(key: key).update_all(["value = value - 1, expires_at = ?", expires_at]) > 0
+          Semaphore.available.where(key: key).update_all([ "value = value - 1, expires_at = ?", expires_at ]) > 0
         end
 
         def attempt_increment
-          Semaphore.where(key: key, value: ...limit).update_all(["value = value + 1, expires_at = ?", expires_at]) > 0
+          Semaphore.where(key: key, value: ...limit).update_all([ "value = value + 1, expires_at = ?", expires_at ]) > 0
         end
 
         def key

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -61,7 +61,7 @@ module SolidQueue
           limit == 1 ? false : attempt_decrement
         end
 
-        if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+        if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
           alias attempt_creation attempt_creation_with_insert_on_conflict
         else
           alias attempt_creation attempt_creation_with_create_and_exception_handling

--- a/test/integration/concurrency_controls_test.rb
+++ b/test/integration/concurrency_controls_test.rb
@@ -83,7 +83,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
 
     # C would have started in the beginning, seeing the status empty, and would finish after
     # all other jobs, so it'll do the last update with only itself
-    assert_stored_sequence(@result, ["C"])
+    assert_stored_sequence(@result, [ "C" ])
   end
 
   test "run several jobs over the same record sequentially, with some of them failing" do
@@ -99,7 +99,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
     wait_for_jobs_to_finish_for(3.seconds)
     assert_equal 3, SolidQueue::FailedExecution.count
 
-    assert_stored_sequence @result, ["B", "D", "F"] + ("G".."K").to_a
+    assert_stored_sequence @result, [ "B", "D", "F" ] + ("G".."K").to_a
   end
 
   test "rely on dispatcher to unblock blocked executions with an available semaphore" do
@@ -133,7 +133,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
 
     # We can't ensure the order between B and C, because it depends on which worker wins when
     # unblocking, as one will try to unblock B and another C
-    assert_stored_sequence @result, ("A".."K").to_a, ["A", "C", "B"] + ("D".."K").to_a
+    assert_stored_sequence @result, ("A".."K").to_a, [ "A", "C", "B" ] + ("D".."K").to_a
   end
 
   test "rely on dispatcher to unblock blocked executions with an expired semaphore" do
@@ -165,7 +165,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
 
     # We can't ensure the order between B and C, because it depends on which worker wins when
     # unblocking, as one will try to unblock B and another C
-    assert_stored_sequence @result, ("A".."K").to_a, ["A", "C", "B"] + ("D".."K").to_a
+    assert_stored_sequence @result, ("A".."K").to_a, [ "A", "C", "B" ] + ("D".."K").to_a
   end
 
   test "don't block claimed executions that get released" do


### PR DESCRIPTION
Per all of my earlier discussion, Postgres transactions become invalid upon any database contraint invalidating an operation and make all follow on database interactions invalid until a rollback is executed.

Semephore#attempt_creation uses a rather common database pattern to rely on database locks to reliably syncrhronize based on uniqueness of values.  The catch is that Postgresql requires a little more handholding to use this pattern.  By wrapping just the Semaphore.create statement in a SAVEPOINT (a pretend nested transaction), we have what appears to be a transparent operation that works across all of the other supported databases without any known consequences AND allows Postgres to continue to work as expected per the existing code.

This change works across the Solid supported databases (at least based on the tests) and I believe the extra overhead for the non-postgres databases is small enough that special casing the code or resorting to the complexity of dependency injection is just not worth it.

I added two tests to the concurrency_controls_test.rb. One to show the error is real and is easy to reproduce. The other to show the fix fixes it.