### PR TITLE
Fix setting Rails logger by default.

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -20,7 +20,9 @@ loader.setup
 module SolidQueue
   extend self
 
-  mattr_accessor :logger, default: ActiveSupport::Logger.new($stdout)
+  DEFAULT_LOGGER = ActiveSupport::Logger.new($stdout)
+
+  mattr_accessor :logger, default: DEFAULT_LOGGER
   mattr_accessor :app_executor, :on_thread_error, :connects_to
 
   mattr_accessor :use_skip_locked, default: true
@@ -56,4 +58,6 @@ module SolidQueue
   def instrument(channel, **options, &block)
     ActiveSupport::Notifications.instrument("#{channel}.solid_queue", **options, &block)
   end
+
+  ActiveSupport.run_load_hooks(:solid_queue, self)
 end

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -24,9 +24,9 @@ module SolidQueue
       SolidQueue.on_thread_error = config.solid_queue.on_thread_error
     end
 
-    initializer "solid_queue.logger" do |app|
+    initializer "solid_queue.logger" do
       ActiveSupport.on_load(:solid_queue) do
-        self.logger ||= app.logger
+        self.logger = ::Rails.logger if logger == SolidQueue::DEFAULT_LOGGER
       end
 
       SolidQueue::LogSubscriber.attach_to :solid_queue


### PR DESCRIPTION
In addition, introduce load hooks for `:solid_queue`.

This solution is borrowed from the GoodJob codebase.