### PR TITLE
Release any orphaned claimed executions as part of the process prune

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -3,6 +3,8 @@
 class SolidQueue::ClaimedExecution < SolidQueue::Execution
   belongs_to :process
 
+  scope :orphaned, -> { where.missing(:process) }
+
   class Result < Struct.new(:success, :error)
     def success?
       success

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -20,8 +20,8 @@ class ProcessLifecycleTest < ActiveSupport::TestCase
   end
 
   test "enqueue jobs in multiple queues" do
-    6.times.map { |i| enqueue_store_result_job("job_#{i}") }
-    6.times.map { |i| enqueue_store_result_job("job_#{i}", :default) }
+    6.times { |i| enqueue_store_result_job("job_#{i}") }
+    6.times { |i| enqueue_store_result_job("job_#{i}", :default) }
 
     wait_for_jobs_to_finish_for(0.5.seconds)
 


### PR DESCRIPTION
Orphaned executions shouldn't happen as part of regular operation, but some people have reported them (#159). The only way I can think of this happening could be that a worker gets deregistered while still working normally so that it happens to be claiming executions while the process record is deleted. This means that the callback to release claimed executions might not yet see the executions that are being claimed at the same time, and as such, it won't release any. Or, in other words, those executions would get claimed by a process that's getting deleted and that once they're committed to the DB, it no longer exists.

To recover from this scenario, as well as checking for processes with an expired heartbeat, the supervisor will also check for orphaned executions and release them.