### PR TITLE
Improve error handling on enqueuing

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -37,6 +37,11 @@ module SolidQueue
 
         def create_from_active_job(active_job)
           create!(**attributes_from_active_job(active_job))
+        rescue ActiveRecord::ActiveRecordError => e
+          enqueue_error = ActiveJob::EnqueueError.new("#{e.class.name}: #{e.message}").tap do |error|
+            error.set_backtrace e.backtrace
+          end
+          raise enqueue_error
         end
 
         def create_all_from_active_jobs(active_jobs)

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -2,6 +2,8 @@
 
 module SolidQueue
   class Job < Record
+    class EnqueueError < StandardError; end
+
     include Executable, Clearable, Recurrable
 
     serialize :arguments, coder: JSON
@@ -38,7 +40,7 @@ module SolidQueue
         def create_from_active_job(active_job)
           create!(**attributes_from_active_job(active_job))
         rescue ActiveRecord::ActiveRecordError => e
-          enqueue_error = ActiveJob::EnqueueError.new("#{e.class.name}: #{e.message}").tap do |error|
+          enqueue_error = EnqueueError.new("#{e.class.name}: #{e.message}").tap do |error|
             error.set_backtrace e.backtrace
           end
           raise enqueue_error

--- a/app/models/solid_queue/recurring_execution.rb
+++ b/app/models/solid_queue/recurring_execution.rb
@@ -2,17 +2,21 @@
 
 module SolidQueue
   class RecurringExecution < Execution
+    class AlreadyRecorded < StandardError; end
+
     scope :clearable, -> { where.missing(:job) }
 
     class << self
       def record(task_key, run_at, &block)
         transaction do
           block.call.tap do |active_job|
-            create!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
+            if active_job
+              create!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
+            end
           end
         end
-      rescue ActiveRecord::RecordNotUnique
-        # Task already dispatched
+      rescue ActiveRecord::RecordNotUnique => e
+        raise AlreadyRecorded
       end
 
       def clear_in_batches(batch_size: 500)

--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -51,6 +51,10 @@ module SolidQueue
         recurring_schedule.unload_tasks
       end
 
+      def all_work_completed?
+        SolidQueue::ScheduledExecution.none? && recurring_schedule.empty?
+      end
+
       def set_procline
         procline "waiting"
       end

--- a/lib/solid_queue/dispatcher/recurring_schedule.rb
+++ b/lib/solid_queue/dispatcher/recurring_schedule.rb
@@ -11,6 +11,10 @@ module SolidQueue
       @scheduled_tasks = Concurrent::Hash.new
     end
 
+    def empty?
+      configured_tasks.empty?
+    end
+
     def load_tasks
       configured_tasks.each do |task|
         load_task(task)

--- a/lib/solid_queue/dispatcher/recurring_task.rb
+++ b/lib/solid_queue/dispatcher/recurring_task.rb
@@ -36,12 +36,18 @@ module SolidQueue
         else
           payload[:other_adapter] = true
 
-          perform_later
+          perform_later do |job|
+            unless job.successfully_enqueued?
+              payload[:enqueue_error] = job.enqueue_error&.message
+            end
+          end
         end
 
         payload[:active_job_id] = active_job.job_id if active_job
       rescue RecurringExecution::AlreadyRecorded
         payload[:skipped] = true
+      rescue Job::EnqueueError => error
+        payload[:enqueue_error] = error.message
       end
     end
 
@@ -70,8 +76,8 @@ module SolidQueue
         RecurringExecution.record(key, run_at) { perform_later }
       end
 
-      def perform_later
-        job_class.perform_later(*arguments_with_kwargs)
+      def perform_later(&block)
+        job_class.perform_later(*arguments_with_kwargs, &block)
       end
 
       def arguments_with_kwargs

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -40,7 +40,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def enqueue_recurring_task(event)
-    attributes = event.payload.slice(:task, :active_job_id, :at)
+    attributes = event.payload.slice(:task, :active_job_id, :enqueue_error, :at)
 
     if event.payload[:other_adapter]
       action = attributes[:active_job_id].present? ? "Enqueued recurring task outside Solid Queue" : "Error enqueuing recurring task"

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -241,20 +241,17 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     end
   end
 
-  test "raise ActiveJob::EnqueueError when there's an ActiveRecordError" do
+  test "raise EnqueueError when there's an ActiveRecordError" do
     SolidQueue::Job.stubs(:create!).raises(ActiveRecord::Deadlocked)
 
     active_job = AddToBufferJob.new(1).set(priority: 8, queue: "test")
-    assert_raises ActiveJob::EnqueueError do
+    assert_raises SolidQueue::Job::EnqueueError do
       SolidQueue::Job.enqueue(active_job)
     end
 
-    enqueue_result = AddToBufferJob.perform_later(1) do |job|
-      assert job.enqueue_error.is_a? ActiveJob::EnqueueError
-      assert_not job.successfully_enqueued?
+    assert_raises SolidQueue::Job::EnqueueError do
+      AddToBufferJob.perform_later(1)
     end
-
-    assert_not enqueue_result
   end
 
   if ENV["SEPARATE_CONNECTION"] && ENV["TARGET_DB"] != "sqlite"

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -42,9 +42,9 @@ class LogSubscriberTest < ActiveSupport::TestCase
 
   test "error enqueuing recurring task" do
     attach_log_subscriber
-    instrument "enqueue_recurring_task.solid_queue", task: :example_task, at: Time.now
+    instrument "enqueue_recurring_task.solid_queue", task: :example_task, enqueue_error: "Everything is broken", at: Time.now
 
-    assert_match_logged :info, "Error enqueuing recurring task", "task: :example_task"
+    assert_match_logged :info, "Error enqueuing recurring task", "task: :example_task, enqueue_error: \"Everything is broken\""
   end
 
   private

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -26,6 +26,27 @@ class LogSubscriberTest < ActiveSupport::TestCase
     assert_match_logged :debug, "Unblock jobs", "limit: 42, size: 10"
   end
 
+  test "recurring task enqueued succesfully" do
+    attach_log_subscriber
+    instrument "enqueue_recurring_task.solid_queue", task: :example_task, active_job_id: "b944ddbc-6a37-43c0-b661-4b56e57195f5", at: Time.now
+
+    assert_match_logged :info, "Enqueued recurring task", "task: :example_task, active_job_id: \"b944ddbc-6a37-43c0-b661-4b56e57195f5\""
+  end
+
+  test "recurring task skipped" do
+    attach_log_subscriber
+    instrument "enqueue_recurring_task.solid_queue", task: :example_task, skipped: true, at: Time.now
+
+    assert_match_logged :info, "Skipped recurring task – already dispatched", "task: :example_task"
+  end
+
+  test "error enqueuing recurring task" do
+    attach_log_subscriber
+    instrument "enqueue_recurring_task.solid_queue", task: :example_task, at: Time.now
+
+    assert_match_logged :info, "Error enqueuing recurring task", "task: :example_task"
+  end
+
   private
     def attach_log_subscriber
       ActiveSupport::LogSubscriber.attach_to :solid_queue, SolidQueue::LogSubscriber.new

--- a/test/unit/recurring_task_test.rb
+++ b/test/unit/recurring_task_test.rb
@@ -85,7 +85,7 @@ class RecurringTaskTest < ActiveSupport::TestCase
     end
   end
 
-  test "error when enqueuing job using another adapter" do
+  test "error when enqueuing job using another adapter that raises ActiveJob::EnqueueError" do
     ActiveJob::QueueAdapters::AsyncAdapter.any_instance.stubs(:enqueue).raises(ActiveJob::EnqueueError)
     previous_size = JobBuffer.size
 

--- a/test/unit/recurring_task_test.rb
+++ b/test/unit/recurring_task_test.rb
@@ -25,6 +25,14 @@ class RecurringTaskTest < ActiveSupport::TestCase
     end
   end
 
+  class JobUsingAsyncAdapter < ApplicationJob
+    self.queue_adapter = :async
+
+    def perform
+      JobBuffer.add "job_using_async_adapter"
+    end
+  end
+
   setup do
     @worker = SolidQueue::Worker.new(queues: "*")
     @worker.mode = :inline
@@ -56,6 +64,37 @@ class RecurringTaskTest < ActiveSupport::TestCase
     task = recurring_task_with(class_name: "JobWithMultipleTypeArguments", args:
       [ "multiple_types", value: "regular_hash_value", value_kwarg: 42, not_used: 32 ])
     enqueue_and_assert_performed_with_result task, [ "multiple_types", nil, 42 ]
+  end
+
+  test "job using a different adapter" do
+    task = recurring_task_with(class_name: "JobUsingAsyncAdapter")
+    previous_size = JobBuffer.size
+
+    task.enqueue(at: Time.now)
+    wait_while_with_timeout!(0.5.seconds) { JobBuffer.size == previous_size }
+
+    assert_equal "job_using_async_adapter", JobBuffer.last_value
+  end
+
+  test "error when enqueuing job before recording task" do
+    SolidQueue::Job.stubs(:create!).raises(ActiveRecord::Deadlocked)
+
+    task = recurring_task_with(class_name: "JobWithoutArguments")
+    assert_no_difference -> { SolidQueue::Job.count } do
+      task.enqueue(at: Time.now)
+    end
+  end
+
+  test "error when enqueuing job using another adapter" do
+    ActiveJob::QueueAdapters::AsyncAdapter.any_instance.stubs(:enqueue).raises(ActiveJob::EnqueueError)
+    previous_size = JobBuffer.size
+
+    task = recurring_task_with(class_name: "JobUsingAsyncAdapter")
+    task.enqueue(at: Time.now)
+
+    wait_while_with_timeout(0.5.seconds) { JobBuffer.size == previous_size }
+
+    assert_equal previous_size, JobBuffer.size
   end
 
   test "valid and invalid schedules" do


### PR DESCRIPTION
Some changes related to errors when enqueuing jobs: 
- ~Raise `ActiveJob::EnqueueError` on `ActiveRecordError` on enqueuing, as Active Job expects and handles.~ Raise `SolidQueue::Job::EnqueueError` on  `ActiveRecordError` on enqueuing. The reason is that we can't easily control what happens when something goes wrong on enqueuing if the jobs are enqueued by Rails or other gems (eg. `Turbo::Streams::BroadcastJob`, `ActiveStorage::AnalyzeJob`...), because the only way is to check what the return value of the call to `perform_later` is, or to pass a block to that method to fetch the error that gets set in `enqueue_error`. In this way at least the error will bubble up and you can rescue or let it be raised.
- Fix bug when enqueuing the job for a recurring task fails (reported in #251):  as `perform_later` in this case returns `false`, which crashes when we try to access `job_id` on it. `perform_later` returns the job instance with `successfully_enqueued` set to true when it goes well, but `false` when it fails. You can provide a block and the job instance with `successfully_enqueued` set to `false`, and an error set in `enqueue_error` is yielded to that block, but it's not returned. 
At first, I tried to make this a bit more sophisticated, passing a block to get the job and populate the instrumentation payload with it, but the code was getting quite cumbersome, and the error is instrumented by Active Job anyway, so in the end I just simplified this and opted for handling this case to avoid crashing.
