### PR TITLE
Truncate error backtrace when saving failed executions

### DIFF
--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -33,9 +33,11 @@ module SolidQueue
     end
 
     private
+      BACKTRACE_LINES_LIMIT = 400
+
       def expand_error_details_from_exception
         if exception
-          self.error = { exception_class: exception.class.name, message: exception.message, backtrace: exception.backtrace }
+          self.error = { exception_class: exception.class.name, message: exception.message, backtrace: exception.backtrace.first(BACKTRACE_LINES_LIMIT) }
         end
       end
   end

--- a/test/dummy/app/jobs/infinite_recursion_job.rb
+++ b/test/dummy/app/jobs/infinite_recursion_job.rb
@@ -1,0 +1,20 @@
+class InfiniteRecursionJob < ApplicationJob
+  queue_as :background
+
+  def perform
+    start
+  end
+
+  private
+    def start
+      continue
+    end
+
+    def continue
+      start_again
+    end
+
+    def start_again
+      start
+    end
+end

--- a/test/models/solid_queue/failed_execution_test.rb
+++ b/test/models/solid_queue/failed_execution_test.rb
@@ -14,6 +14,14 @@ class SolidQueue::FailedExecutionTest < ActiveSupport::TestCase
     assert SolidQueue::Job.last.failed?
   end
 
+  test "run job that fails with a SystemStackError (stack level too deep)" do
+    InfiniteRecursionJob.perform_later
+    @worker.start
+
+    assert_equal 1, SolidQueue::FailedExecution.count
+    assert SolidQueue::Job.last.failed?
+  end
+
   test "retry failed job" do
     RaisingJob.perform_later(RuntimeError, "A")
     @worker.start


### PR DESCRIPTION
Otherwise it can get really big for `SystemStackError` errors, and not fit in the DB text column.

Assuming an average of 150 characters per backtrace line, limting to 400 would be around 60K characters plus the error name and error message, that are usually small, and the JSON attributes and other JSON serialization characters.

This is the first approach to this. I'll change this to more sophisticated truncation that checks the column size and calculates how much it needs to truncate instead of using a fixed number.