### PR TITLE
Store canonical recurring tasks in the DB

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,19 @@
+# Upgrading to version 0.5.x
+This version includes a new migration to improve recurring tasks. To install it, just run:
+
+```bash
+$ bin/rails solid_queue:install:migrations
+```
+
+Or, if you're using a different database for Solid Queue:
+
+```bash
+$ bin/rails solid_queue:install:migrations DATABASE=<the_name_of_your_solid_queue_db>
+```
+
+And then run the migrations.
+
+
 # Upgrading to version 0.4.x
 This version introduced an _async_ mode to run the supervisor and have all workers and dispatchers run as part of the same process as the supervisor, instead of separate, forked, processes. Together with this, we introduced some changes in how the supervisor is started. Prior this change, you could choose whether you wanted to run workers, dispatchers or both, by starting Solid Queue as `solid_queue:work` or `solid_queue:dispatch`. From version 0.4.0, the only option available is:
 
@@ -26,7 +42,6 @@ the supervisor will run 1 dispatcher and no workers.
 
 
 # Upgrading to version 0.3.x
-
 This version introduced support for [recurring (cron-style) jobs](https://github.com/rails/solid_queue/blob/main/README.md#recurring-tasks), and it needs a new DB migration for it. To install it, just run:
 
 ```bash

--- a/app/models/solid_queue/recurring_execution.rb
+++ b/app/models/solid_queue/recurring_execution.rb
@@ -7,16 +7,29 @@ module SolidQueue
     scope :clearable, -> { where.missing(:job) }
 
     class << self
+      def create_or_insert!(**attributes)
+        if connection.supports_insert_conflict_target?
+          # PostgreSQL fails and aborts the current transaction when it hits a duplicate key conflict
+          # during two concurrent INSERTs for the same value of an unique index. We need to explicitly
+          # indicate unique_by to ignore duplicate rows by this value when inserting
+          unless insert(attributes, unique_by: [ :task_key, :run_at ]).any?
+            raise AlreadyRecorded
+          end
+        else
+          create!(**attributes)
+        end
+      rescue ActiveRecord::RecordNotUnique
+        raise AlreadyRecorded
+      end
+
       def record(task_key, run_at, &block)
         transaction do
           block.call.tap do |active_job|
             if active_job
-              create!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
+              create_or_insert!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
             end
           end
         end
-      rescue ActiveRecord::RecordNotUnique => e
-        raise AlreadyRecorded
       end
 
       def clear_in_batches(batch_size: 500)

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -1,24 +1,17 @@
 require "fugit"
 
 module SolidQueue
-  class Dispatcher::RecurringTask
+  class RecurringTask < Record
+    serialize :arguments, coder: JSON
+
     class << self
       def wrap(args)
         args.is_a?(self) ? args : from_configuration(args.first, **args.second)
       end
 
       def from_configuration(key, **options)
-        new(key, class_name: options[:class], schedule: options[:schedule], arguments: options[:args])
+        new(key: key, class_name: options[:class], schedule: options[:schedule], arguments: options[:args] || [])
       end
-    end
-
-    attr_reader :key, :schedule, :class_name, :arguments
-
-    def initialize(key, class_name:, schedule:, arguments: nil)
-      @key = key
-      @class_name = class_name
-      @schedule = schedule
-      @arguments = Array(arguments)
     end
 
     def delay_from_now

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -2,7 +2,7 @@ require "fugit"
 
 module SolidQueue
   class RecurringTask < Record
-    serialize :arguments, coder: JSON
+    serialize :arguments, coder: Arguments, default: []
 
     class << self
       def wrap(args)
@@ -10,7 +10,7 @@ module SolidQueue
       end
 
       def from_configuration(key, **options)
-        new(key: key, class_name: options[:class], schedule: options[:schedule], arguments: options[:args] || [])
+        new(key: key, class_name: options[:class], schedule: options[:schedule], arguments: options[:args])
       end
     end
 

--- a/app/models/solid_queue/recurring_task/arguments.rb
+++ b/app/models/solid_queue/recurring_task/arguments.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "active_job/arguments"
+
 module SolidQueue
   class RecurringTask::Arguments
     class << self
@@ -6,7 +10,7 @@ module SolidQueue
       end
 
       def dump(data)
-        ActiveSupport::JSON.dump(ActiveJob::Arguments.serialize(data)) unless data.nil?
+        ActiveSupport::JSON.dump(ActiveJob::Arguments.serialize(Array(data)))
       end
     end
   end

--- a/app/models/solid_queue/recurring_task/arguments.rb
+++ b/app/models/solid_queue/recurring_task/arguments.rb
@@ -1,0 +1,13 @@
+module SolidQueue
+  class RecurringTask::Arguments
+    class << self
+      def load(data)
+        data.nil? ? [] : ActiveJob::Arguments.deserialize(ActiveSupport::JSON.load(data))
+      end
+
+      def dump(data)
+        ActiveSupport::JSON.dump(ActiveJob::Arguments.serialize(data)) unless data.nil?
+      end
+    end
+  end
+end

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -52,7 +52,6 @@ module SolidQueue
       end
 
       private
-
         attr_accessor :job
 
         def attempt_creation
@@ -63,7 +62,9 @@ module SolidQueue
           end
         end
 
-        def check_limit_or_decrement = limit == 1 ? false : attempt_decrement
+        def check_limit_or_decrement
+          limit == 1 ? false : attempt_decrement
+        end
 
         def attempt_decrement
           Semaphore.available.where(key: key).update_all([ "value = value - 1, expires_at = ?", expires_at ]) > 0

--- a/db/migrate/20240719134516_create_recurring_tasks.rb
+++ b/db/migrate/20240719134516_create_recurring_tasks.rb
@@ -6,6 +6,8 @@ class CreateRecurringTasks < ActiveRecord::Migration[7.1]
       t.string :class_name, null: false
       t.text :arguments
 
+      t.boolean :static, default: true, index: true
+
       t.timestamps
     end
   end

--- a/db/migrate/20240719134516_create_recurring_tasks.rb
+++ b/db/migrate/20240719134516_create_recurring_tasks.rb
@@ -3,10 +3,16 @@ class CreateRecurringTasks < ActiveRecord::Migration[7.1]
     create_table :solid_queue_recurring_tasks do |t|
       t.string :key, null: false, index: { unique: true }
       t.string :schedule, null: false
-      t.string :class_name, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
       t.text :arguments
 
+      t.string :queue_name
+      t.integer :priority, default: 0
+
       t.boolean :static, default: true, index: true
+
+      t.text :description
 
       t.timestamps
     end

--- a/db/migrate/20240719134516_create_recurring_tasks.rb
+++ b/db/migrate/20240719134516_create_recurring_tasks.rb
@@ -1,0 +1,12 @@
+class CreateRecurringTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false, index: { unique: true }
+      t.string :schedule, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -75,7 +75,7 @@ module SolidQueue
 
       def parse_recurring_tasks(tasks)
         Array(tasks).map do |id, options|
-          Dispatcher::RecurringTask.from_configuration(id, **options)
+          RecurringTask.from_configuration(id, **options)
         end.select(&:valid?)
       end
 

--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -4,8 +4,8 @@ module SolidQueue
   class Dispatcher < Processes::Poller
     attr_accessor :batch_size, :concurrency_maintenance, :recurring_schedule
 
-    after_boot :start_concurrency_maintenance, :load_recurring_schedule
-    before_shutdown :stop_concurrency_maintenance, :unload_recurring_schedule
+    after_boot :start_concurrency_maintenance, :schedule_recurring_tasks
+    before_shutdown :stop_concurrency_maintenance, :unschedule_recurring_tasks
 
     def initialize(**options)
       options = options.dup.with_defaults(SolidQueue::Configuration::DISPATCHER_DEFAULTS)
@@ -19,7 +19,7 @@ module SolidQueue
     end
 
     def metadata
-      super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval, recurring_schedule: recurring_schedule.tasks.presence)
+      super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval, recurring_schedule: recurring_schedule.task_keys.presence)
     end
 
     private
@@ -38,16 +38,16 @@ module SolidQueue
         concurrency_maintenance&.start
       end
 
-      def load_recurring_schedule
-        recurring_schedule.load_tasks
+      def schedule_recurring_tasks
+        recurring_schedule.schedule_tasks
       end
 
       def stop_concurrency_maintenance
         concurrency_maintenance&.stop
       end
 
-      def unload_recurring_schedule
-        recurring_schedule.unload_tasks
+      def unschedule_recurring_tasks
+        recurring_schedule.unschedule_tasks
       end
 
       def all_work_completed?

--- a/lib/solid_queue/dispatcher/recurring_schedule.rb
+++ b/lib/solid_queue/dispatcher/recurring_schedule.rb
@@ -7,7 +7,7 @@ module SolidQueue
     attr_reader :configured_tasks, :scheduled_tasks
 
     def initialize(tasks)
-      @configured_tasks = Array(tasks).map { |task| Dispatcher::RecurringTask.wrap(task) }
+      @configured_tasks = Array(tasks).map { |task| SolidQueue::RecurringTask.wrap(task) }
       @scheduled_tasks = Concurrent::Hash.new
     end
 

--- a/lib/solid_queue/dispatcher/recurring_schedule.rb
+++ b/lib/solid_queue/dispatcher/recurring_schedule.rb
@@ -33,8 +33,6 @@ module SolidQueue
     def unschedule_tasks
       scheduled_tasks.values.each(&:cancel)
       scheduled_tasks.clear
-
-      wrap_in_app_executor { delete_tasks }
     end
 
     def task_keys
@@ -48,10 +46,6 @@ module SolidQueue
 
       def reload_tasks
         @configured_tasks = SolidQueue::RecurringTask.where(key: task_keys)
-      end
-
-      def delete_tasks
-        SolidQueue::RecurringTask.static.delete_all
       end
 
       def schedule(task)

--- a/lib/solid_queue/dispatcher/recurring_schedule.rb
+++ b/lib/solid_queue/dispatcher/recurring_schedule.rb
@@ -7,7 +7,7 @@ module SolidQueue
     attr_reader :configured_tasks, :scheduled_tasks
 
     def initialize(tasks)
-      @configured_tasks = Array(tasks).map { |task| SolidQueue::RecurringTask.wrap(task) }
+      @configured_tasks = Array(tasks).map { |task| SolidQueue::RecurringTask.wrap(task) }.select(&:valid?)
       @scheduled_tasks = Concurrent::Hash.new
     end
 
@@ -15,33 +15,48 @@ module SolidQueue
       configured_tasks.empty?
     end
 
-    def load_tasks
+    def schedule_tasks
+      wrap_in_app_executor do
+        persist_tasks
+        reload_tasks
+      end
+
       configured_tasks.each do |task|
-        load_task(task)
+        schedule_task(task)
       end
     end
 
-    def load_task(task)
+    def schedule_task(task)
       scheduled_tasks[task.key] = schedule(task)
     end
 
-    def unload_tasks
+    def unschedule_tasks
       scheduled_tasks.values.each(&:cancel)
       scheduled_tasks.clear
+
+      wrap_in_app_executor { delete_tasks }
     end
 
-    def tasks
-      configured_tasks.each_with_object({}) { |task, hsh| hsh[task.key] = task.to_h }
-    end
-
-    def inspect
-      configured_tasks.map(&:to_s).join(" | ")
+    def task_keys
+      configured_tasks.map(&:key)
     end
 
     private
+      def persist_tasks
+        SolidQueue::RecurringTask.upsert_all configured_tasks.map(&:attributes_for_upsert), record_timestamps: true
+      end
+
+      def reload_tasks
+        @configured_tasks = SolidQueue::RecurringTask.where(key: task_keys)
+      end
+
+      def delete_tasks
+        SolidQueue::RecurringTask.static.delete_all
+      end
+
       def schedule(task)
         scheduled_task = Concurrent::ScheduledTask.new(task.delay_from_now, args: [ self, task, task.next_time ]) do |thread_schedule, thread_task, thread_task_run_at|
-          thread_schedule.load_task(thread_task)
+          thread_schedule.schedule_task(thread_task)
 
           wrap_in_app_executor do
             thread_task.enqueue(at: thread_task_run_at)

--- a/lib/solid_queue/dispatcher/recurring_schedule.rb
+++ b/lib/solid_queue/dispatcher/recurring_schedule.rb
@@ -43,7 +43,7 @@ module SolidQueue
 
     private
       def persist_tasks
-        SolidQueue::RecurringTask.upsert_all configured_tasks.map(&:attributes_for_upsert), record_timestamps: true
+        SolidQueue::RecurringTask.create_or_update_all configured_tasks
       end
 
       def reload_tasks

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -104,9 +104,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_19_134516) do
   create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "schedule", null: false
-    t.string "class_name", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
     t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
     t.boolean "static", default: true
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_18_110712) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_19_134516) do
   create_table "job_results", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name"
     t.string "status"
@@ -99,6 +99,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_18_110712) do
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
   end
 
   create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -106,9 +106,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_19_134516) do
     t.string "schedule", null: false
     t.string "class_name", null: false
     t.text "arguments"
+    t.boolean "static", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -289,7 +289,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert events.size >= 1
     event = events.last
 
-    assert_event event, "enqueue_recurring_task", task: :example_task, active_job_id: SolidQueue::Job.last.active_job_id
+    assert_event event, "enqueue_recurring_task", task: "example_task", active_job_id: SolidQueue::Job.last.active_job_id
     assert event.last[:at].present?
     assert_nil event.last[:other_adapter]
   end

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -306,7 +306,7 @@ class InstrumentationTest < ActiveSupport::TestCase
 
     assert events.size >= 2
     events.each do |event|
-      assert_event event, "enqueue_recurring_task", task: :example_task
+      assert_event event, "enqueue_recurring_task", task: "example_task"
     end
 
     active_job_ids = SolidQueue::Job.all.map(&:active_job_id)
@@ -333,7 +333,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert events.size >= 1
     event = events.last
 
-    assert_event event, "enqueue_recurring_task", task: :example_task, enqueue_error: "ActiveRecord::Deadlocked: ActiveRecord::Deadlocked"
+    assert_event event, "enqueue_recurring_task", task: "example_task", enqueue_error: "ActiveRecord::Deadlocked: ActiveRecord::Deadlocked"
     assert event.last[:at].present?
     assert_nil event.last[:other_adapter]
   end
@@ -354,7 +354,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert events.size >= 1
     event = events.last
 
-    assert_event event, "enqueue_recurring_task", task: :example_task, enqueue_error: "All is broken"
+    assert_event event, "enqueue_recurring_task", task: "example_task", enqueue_error: "All is broken"
     assert event.last[:at].present?
     assert event.last[:other_adapter]
   ensure

--- a/test/integration/puma/plugin_testing.rb
+++ b/test/integration/puma/plugin_testing.rb
@@ -32,16 +32,14 @@ module PluginTesting
     teardown do
       terminate_process(@pid, signal: :INT) if process_exists?(@pid)
 
-      wait_for_registered_processes 0, timeout: 1.second
-
-      JobResult.delete_all
+      wait_for_registered_processes 0, timeout: 2.seconds
     end
   end
 
   test "perform jobs inside puma's process" do
     StoreResultJob.perform_later(:puma_plugin)
 
-    wait_for_jobs_to_finish_for(1.second)
+    wait_for_jobs_to_finish_for(2.seconds)
     assert_equal 1, JobResult.where(queue_name: :background, status: "completed", value: :puma_plugin).count
   end
 

--- a/test/integration/recurring_tasks_test.rb
+++ b/test/integration/recurring_tasks_test.rb
@@ -48,9 +48,9 @@ class RecurringTasksTest < ActiveSupport::TestCase
 
     assert_recurring_tasks configured_task
     terminate_process(@pid)
-    assert_recurring_tasks []
 
-    SolidQueue::RecurringTask.create!(key: "periodic_store_result", class_name: "StoreResultJob", schedule: "every minute", arguments: [ 42 ])
+    task = SolidQueue::RecurringTask.find_by(key: "periodic_store_result")
+    task.update!(class_name: "StoreResultJob", schedule: "every minute", arguments: [ 42 ])
 
     @pid = run_supervisor_as_fork
     wait_for_registered_processes(4, timeout: 3.second)
@@ -75,8 +75,6 @@ class RecurringTasksTest < ActiveSupport::TestCase
     terminate_process(@pid)
     dispatcher1.stop
     dispatcher2.stop
-
-    assert_recurring_tasks []
   end
 
   private

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -3,11 +3,6 @@ require "test_helper"
 class SolidQueue::JobTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
-  teardown do
-    SolidQueue::Job.destroy_all
-    JobResult.delete_all
-  end
-
   class NonOverlappingJob < ApplicationJob
     limits_concurrency key: ->(job_result, **) { job_result }
 

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RecurringTaskTest < ActiveSupport::TestCase
+class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
   class JobWithoutArguments < ApplicationJob
     def perform
       JobBuffer.add "job_without_arguments"
@@ -130,6 +130,6 @@ class RecurringTaskTest < ActiveSupport::TestCase
     end
 
     def recurring_task_with(class_name:, schedule: "every hour", args: nil)
-      SolidQueue::Dispatcher::RecurringTask.from_configuration("task-id", class: "RecurringTaskTest::#{class_name}", schedule: schedule, args: args)
+      SolidQueue::RecurringTask.from_configuration("task-id", class: "SolidQueue::RecurringTaskTest::#{class_name}", schedule: schedule, args: args)
     end
 end

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -114,6 +114,16 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every second")
     assert task.valid?
     assert task.to_s.ends_with? "[ * * * * * * ]"
+
+    # Empty schedule
+    assert_not SolidQueue::RecurringTask.new(key: "task-id", class_name: "SolidQueue::RecurringTaskTest::JobWithoutArguments").valid?
+  end
+
+  test "undefined job class" do
+    assert_not recurring_task_with(class_name: "UnknownJob").valid?
+
+    # Empty class name
+    assert_not SolidQueue::RecurringTask.new(key: "task-id", schedule: "every minute").valid?
   end
 
   private
@@ -130,6 +140,6 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     end
 
     def recurring_task_with(class_name:, schedule: "every hour", args: nil)
-      SolidQueue::RecurringTask.from_configuration("task-id", class: "SolidQueue::RecurringTaskTest::#{class_name}", schedule: schedule, args: args)
+      SolidQueue::RecurringTask.new(key: "task-id", class_name: "SolidQueue::RecurringTaskTest::#{class_name}", schedule: schedule, arguments: args)
     end
 end

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -51,8 +51,7 @@ class DispatcherTest < ActiveSupport::TestCase
     assert_equal "Dispatcher", process.kind
 
     schedule_from_metadata = process.metadata["recurring_schedule"]
-    assert_equal 1, schedule_from_metadata.size
-    assert_equal({ "class_name" => "AddToBufferJob", "schedule" => "every hour", "arguments" => [ 42 ] }, schedule_from_metadata["example_task"])
+    assert_equal [ "example_task" ], schedule_from_metadata
   ensure
     with_recurring_schedule.stop
   end

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -12,8 +12,6 @@ class DispatcherTest < ActiveSupport::TestCase
 
   teardown do
     @dispatcher.stop
-    SolidQueue::Job.delete_all
-    SolidQueue::Process.delete_all
   end
 
   test "dispatcher is registered as process" do
@@ -87,6 +85,10 @@ class DispatcherTest < ActiveSupport::TestCase
         sleep 0.2
       end
     end
+
+    @dispatcher.stop
+    wait_for_registered_processes(0, timeout: 1.second)
+    assert_no_registered_processes
   end
 
   test "run more than one instance of the dispatcher without recurring tasks" do
@@ -100,13 +102,13 @@ class DispatcherTest < ActiveSupport::TestCase
     @dispatcher.start
     another_dispatcher.start
 
-    sleep 0.5
+    sleep(0.7.seconds)
 
     assert_equal 0, SolidQueue::ScheduledExecution.count
     assert_equal 15, SolidQueue::ReadyExecution.count
 
   ensure
-    another_dispatcher.stop
+    another_dispatcher&.stop
   end
 
   test "run more than one instance of the dispatcher with recurring tasks" do

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -12,8 +12,6 @@ class ForkSupervisorTest < ActiveSupport::TestCase
   teardown do
     SolidQueue.supervisor_pidfile = @previous_pidfile
     File.delete(@pidfile) if File.exist?(@pidfile)
-
-    SolidQueue::Process.destroy_all
   end
 
   test "start" do
@@ -32,7 +30,7 @@ class ForkSupervisorTest < ActiveSupport::TestCase
   test "start with provided configuration" do
     config_as_hash = { workers: [], dispatchers: [ { batch_size: 100 } ] }
     pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
-    wait_for_registered_processes(2) # supervisor + dispatcher
+    wait_for_registered_processes(2, timeout: 2) # supervisor + dispatcher
 
     assert_registered_supervisor(pid)
     assert_registered_workers(count: 0)

--- a/test/unit/hooks_test.rb
+++ b/test/unit/hooks_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class HooksTest < ActiveSupport::TestCase
   test "solid_queue_record hook ran" do
+    SolidQueue::Record
     assert Rails.application.config.x.solid_queue_record_hook_ran
   end
 end

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -78,7 +78,7 @@ class WorkerTest < ActiveSupport::TestCase
 
     @worker.start
 
-    wait_for_jobs_to_finish_for(1.second)
+    wait_for_jobs_to_finish_for(2.second)
     @worker.wake_up
 
     assert_equal 5, JobResult.where(queue_name: :background, status: "completed", value: :paused).count
@@ -116,6 +116,10 @@ class WorkerTest < ActiveSupport::TestCase
         sleep 0.2
       end
     end
+
+    @worker.stop
+    wait_for_registered_processes(0, timeout: 1.second)
+    assert_no_registered_processes
   end
 
   test "run inline" do


### PR DESCRIPTION
This is a pre-requisite to add support for dynamic recurring tasks in the future and to allow for the execution of a task on-demand, for example, from Mission Control. 