### PR TITLE
Fail in-progress jobs when the worker running them exits abnormally

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,28 @@
+# Upgrading to version 0.6.x
+
+## New migration in 3 steps
+This version adds a new migration to the `solid_queue_processes` table. This migration adds a new column that needs to be `NOT NULL`. It will run in three steps:
+1. Add the new column, nullable
+2. Backfill existing rows that would have the column as NULL
+3. Make the column not nullable and add a new index
+
+To install it:
+```bash
+$ bin/rails solid_queue:install:migrations
+```
+
+Or, if you're using a different database for Solid Queue:
+
+```bash
+$ bin/rails solid_queue:install:migrations DATABASE=<the_name_of_your_solid_queue_db>
+```
+
+And then just run it.
+
+## New behaviour when workers are killed
+From this version onwards, when a worker is killed and the supervisor can detect that, it'll fail in-progress jobs claimed by that worker. For this to work correctly, you need to run the above migration and ensure you restart any supervisors you'd have. 
+
+
 # Upgrading to version 0.5.x
 This version includes a new migration to improve recurring tasks. To install it, just run:
 

--- a/app/models/solid_queue/process/executor.rb
+++ b/app/models/solid_queue/process/executor.rb
@@ -11,6 +11,12 @@ module SolidQueue
         after_destroy -> { claimed_executions.release_all }, if: :claims_executions?
       end
 
+      def fail_all_claimed_executions_with(error)
+        if claims_executions?
+          claimed_executions.fail_all_with(error)
+        end
+      end
+
       private
         def claims_executions?
           kind == "Worker"

--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module SolidQueue
+  class ProcessPrunedError < RuntimeError
+    def initialize(last_heartbeat_at)
+      super("Process was found dead and pruned (last heartbeat at: #{last_heartbeat_at}")
+    end
+  end
+
   class Process
     module Prunable
       extend ActiveSupport::Concern
@@ -15,10 +21,17 @@ module SolidQueue
             prunable.non_blocking_lock.find_in_batches(batch_size: 50) do |batch|
               payload[:size] += batch.size
 
-              batch.each { |process| process.deregister(pruned: true) }
+              batch.each(&:prune)
             end
           end
         end
+      end
+
+      def prune
+        error = ProcessPrunedError.new(last_heartbeat_at)
+        fail_all_claimed_executions_with(error)
+
+        deregister(pruned: true)
       end
     end
   end

--- a/db/migrate/20240811173327_add_name_to_processes.rb
+++ b/db/migrate/20240811173327_add_name_to_processes.rb
@@ -1,18 +1,5 @@
 class AddNameToProcesses < ActiveRecord::Migration[7.1]
-  def up
+  def change
     add_column :solid_queue_processes, :name, :string
-
-    SolidQueue::Process.find_each do |process|
-      process.name ||= [ process.kind.downcase, SecureRandom.hex(10) ].join("-")
-      process.save!
-    end
-
-    add_index :solid_queue_processes, [ :name, :supervisor_id ], unique: true
-    change_column :solid_queue_processes, :name, :string, null: false
-  end
-
-  def down
-    remove_index :solid_queue_processes, [ :name, :supervisor_id ]
-    remove_column :solid_queue_processes, :name
   end
 end

--- a/db/migrate/20240811173327_add_name_to_processes.rb
+++ b/db/migrate/20240811173327_add_name_to_processes.rb
@@ -1,0 +1,18 @@
+class AddNameToProcesses < ActiveRecord::Migration[7.1]
+  def up
+    add_column :solid_queue_processes, :name, :string
+
+    SolidQueue::Process.find_each do |process|
+      process.name ||= [ process.kind.downcase, SecureRandom.hex(10) ].join("-")
+      process.save!
+    end
+
+    add_index :solid_queue_processes, [ :name, :supervisor_id ], unique: true
+    change_column :solid_queue_processes, :name, :string, null: false
+  end
+
+  def down
+    remove_index :solid_queue_processes, [ :name, :supervisor_id ]
+    remove_column :solid_queue_processes, :name
+  end
+end

--- a/db/migrate/20240813160053_make_name_not_null.rb
+++ b/db/migrate/20240813160053_make_name_not_null.rb
@@ -1,0 +1,16 @@
+class MakeNameNotNull < ActiveRecord::Migration[7.1]
+  def up
+    SolidQueue::Process.where(name: nil).find_each do |process|
+      process.name ||= [ process.kind.downcase, SecureRandom.hex(10) ].join("-")
+      process.save!
+    end
+
+    change_column :solid_queue_processes, :name, :string, null: false
+    add_index :solid_queue_processes, [ :name, :supervisor_id ], unique: true
+  end
+
+  def down
+    remove_index :solid_queue_processes, [ :name, :supervisor_id ]
+    change_column :solid_queue_processes, :name, :string, null: false
+  end
+end

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -63,7 +63,8 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     attributes = {
       pid: process.pid,
       hostname: process.hostname,
-      process_id: process.process_id
+      process_id: process.process_id,
+      name: process.name
     }.merge(process.metadata)
 
     info formatted_event(event, action: "Started #{process.kind}", **attributes)
@@ -75,7 +76,8 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     attributes = {
       pid: process.pid,
       hostname: process.hostname,
-      process_id: process.process_id
+      process_id: process.process_id,
+      name: process.name
     }.merge(process.metadata)
 
     info formatted_event(event, action: "Shutdown #{process.kind}", **attributes)
@@ -83,7 +85,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
 
   def register_process(event)
     process_kind = event.payload[:kind]
-    attributes = event.payload.slice(:pid, :hostname, :process_id)
+    attributes = event.payload.slice(:pid, :hostname, :process_id, :name)
 
     if error = event.payload[:error]
       warn formatted_event(event, action: "Error registering #{process_kind}", **attributes.merge(error: formatted_error(error)))
@@ -99,6 +101,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
       process_id: process.id,
       pid: process.pid,
       hostname: process.hostname,
+      name: process.name,
       last_heartbeat_at: process.last_heartbeat_at.iso8601,
       claimed_size: event.payload[:claimed_size],
       pruned: event.payload[:pruned]
@@ -147,7 +150,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
       termsig: status.termsig
 
     if replaced_fork = event.payload[:fork]
-      info formatted_event(event, action: "Replaced terminated #{replaced_fork.kind}", **attributes.merge(hostname: replaced_fork.hostname))
+      info formatted_event(event, action: "Replaced terminated #{replaced_fork.kind}", **attributes.merge(hostname: replaced_fork.hostname, name: replaced_fork.name))
     else
       warn formatted_event(event, action: "Tried to replace forked process but it had already died", **attributes)
     end

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -12,11 +12,15 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def release_many_claimed(event)
-    debug formatted_event(event, action: "Release claimed jobs", **event.payload.slice(:size))
+    info formatted_event(event, action: "Release claimed jobs", **event.payload.slice(:size))
+  end
+
+  def fail_many_claimed(event)
+    warn formatted_event(event, action: "Fail claimed jobs", **event.payload.slice(:job_ids, :process_ids))
   end
 
   def release_claimed(event)
-    debug formatted_event(event, action: "Release claimed job", **event.payload.slice(:job_id, :process_id))
+    info formatted_event(event, action: "Release claimed job", **event.payload.slice(:job_id, :process_id))
   end
 
   def retry_all(event)

--- a/lib/solid_queue/processes/base.rb
+++ b/lib/solid_queue/processes/base.rb
@@ -25,7 +25,7 @@ module SolidQueue
       end
 
       def metadata
-        { name: name }
+        {}
       end
 
       private

--- a/lib/solid_queue/processes/base.rb
+++ b/lib/solid_queue/processes/base.rb
@@ -6,6 +6,12 @@ module SolidQueue
       include Callbacks # Defines callbacks needed by other concerns
       include AppExecutor, Registrable, Interruptible, Procline
 
+      attr_reader :name
+
+      def initialize(*)
+        @name = generate_name
+      end
+
       def kind
         self.class.name.demodulize
       end
@@ -19,8 +25,13 @@ module SolidQueue
       end
 
       def metadata
-        {}
+        { name: name }
       end
+
+      private
+        def generate_name
+          [ kind.downcase, SecureRandom.hex(10) ].join("-")
+        end
     end
   end
 end

--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -8,6 +8,8 @@ module SolidQueue::Processes
 
     def initialize(polling_interval:, **options)
       @polling_interval = polling_interval
+
+      super(**options)
     end
 
     def metadata

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -21,6 +21,7 @@ module SolidQueue::Processes
       def register
         @process = SolidQueue::Process.register \
           kind: kind,
+          name: name,
           pid: pid,
           hostname: hostname,
           supervisor: try(:supervisor),

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -25,10 +25,6 @@ module SolidQueue::Processes
       @thread&.join
     end
 
-    def name
-      @name ||= [ kind.downcase, SecureRandom.hex(6) ].join("-")
-    end
-
     def alive?
       !running_async? || @thread.alive?
     end

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -16,6 +16,7 @@ module SolidQueue
 
     def initialize(configuration)
       @configuration = configuration
+      super
     end
 
     def start
@@ -44,7 +45,7 @@ module SolidQueue
       end
 
       def start_processes
-        configuration.processes.each { |configured_process| start_process(configured_process) }
+        configuration.configured_processes.each { |configured_process| start_process(configured_process) }
       end
 
       def stopped?

--- a/lib/solid_queue/supervisor/async_supervisor.rb
+++ b/lib/solid_queue/supervisor/async_supervisor.rb
@@ -23,10 +23,13 @@ module SolidQueue
       attr_reader :threads
 
       def start_process(configured_process)
-        configured_process.supervised_by process
-        configured_process.start
+        process_instance = configured_process.instantiate.tap do |instance|
+          instance.supervised_by process
+        end
 
-        threads[configured_process.name] = configured_process
+        process_instance.start
+
+        threads[process_instance.name] = process_instance
       end
 
       def stop_threads

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -78,7 +78,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_19_165045) do
     t.string "hostname"
     t.text "metadata"
     t.datetime "created_at", null: false
+    t.string "name", null: false
     t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 

--- a/test/integration/forked_processes_lifecycle_test.rb
+++ b/test/integration/forked_processes_lifecycle_test.rb
@@ -104,7 +104,7 @@ class ForkedProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 0.2.seconds)
 
-    signal_process(@pid, :INT, wait: 0.1.second)
+    signal_process(@pid, :INT, wait: 0.3.second)
     wait_for_jobs_to_finish_for(2.second)
 
     assert_completed_job_results("no pause")

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -113,7 +113,7 @@ class InstrumentationTest < ActiveSupport::TestCase
 
   test "pruning processes emit prune_processes and deregister_process events" do
     time = Time.now
-    processes = 3.times.collect { |i| SolidQueue::Process.create!(kind: "Worker", supervisor_id: 42, pid: 10 + i, hostname: "localhost", last_heartbeat_at: time) }
+    processes = 3.times.collect { |i| SolidQueue::Process.create!(kind: "Worker", supervisor_id: 42, pid: 10 + i, hostname: "localhost", last_heartbeat_at: time, name: "worker-123#{i}") }
 
     # Heartbeats will expire
     travel_to 3.days.from_now

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
   setup do
-    @process = SolidQueue::Process.register(kind: "Worker", pid: 42, metadata: { queue: "background" })
+    @process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123", metadata: { queue: "background" })
   end
 
   test "perform job successfully" do

--- a/test/models/solid_queue/process_test.rb
+++ b/test/models/solid_queue/process_test.rb
@@ -15,6 +15,25 @@ class SolidQueue::ProcessTest < ActiveSupport::TestCase
     end
   end
 
+  test "prune processes with expired heartbeats and fail claimed executions" do
+    process = SolidQueue::Process.register(kind: "Worker", pid: 43, name: "worker-43")
+    3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
+    jobs = SolidQueue::Job.last(3)
+
+    SolidQueue::ReadyExecution.claim("*", 5, process.id)
+
+    travel_to 10.minutes.from_now
+
+    assert_difference -> { SolidQueue::FailedExecution.count }, 3 do
+      assert_difference -> { SolidQueue::ClaimedExecution.count }, -3 do
+        SolidQueue::Process.prune
+      end
+    end
+
+    jobs.each(&:reload)
+    assert jobs.all?(&:failed?)
+  end
+
   test "hostname's with special characters are properly loaded" do
     worker = SolidQueue::Worker.new(queues: "*", threads: 3, polling_interval: 0.2)
     hostname = "Basecamp’s-Computer"

--- a/test/models/solid_queue/process_test.rb
+++ b/test/models/solid_queue/process_test.rb
@@ -3,12 +3,12 @@ require "minitest/mock"
 
 class SolidQueue::ProcessTest < ActiveSupport::TestCase
   test "prune processes with expired heartbeats" do
-    SolidQueue::Process.register(kind: "Worker", pid: 42)
-    SolidQueue::Process.register(kind: "Worker", pid: 43)
+    SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-42")
+    SolidQueue::Process.register(kind: "Worker", pid: 43, name: "worker-43")
 
     travel_to 10.minutes.from_now
 
-    SolidQueue::Process.register(kind: "Worker", pid: 44)
+    SolidQueue::Process.register(kind: "Worker", pid: 44, name: "worker-44")
 
     assert_difference -> { SolidQueue::Process.count }, -2 do
       SolidQueue::Process.prune

--- a/test/unit/async_supervisor_test.rb
+++ b/test/unit/async_supervisor_test.rb
@@ -30,7 +30,7 @@ class AsyncSupervisorTest < ActiveSupport::TestCase
 
   test "release orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
-    process = SolidQueue::Process.register(kind: "Worker", pid: 42)
+    process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")
 
     SolidQueue::ReadyExecution.claim("*", 5, process.id)
 

--- a/test/unit/async_supervisor_test.rb
+++ b/test/unit/async_supervisor_test.rb
@@ -28,7 +28,7 @@ class AsyncSupervisorTest < ActiveSupport::TestCase
     assert_no_registered_processes
   end
 
-  test "release orphaned executions" do
+  test "failed orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
     process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")
 
@@ -54,7 +54,7 @@ class AsyncSupervisorTest < ActiveSupport::TestCase
     supervisor.stop
 
     assert_equal 0, SolidQueue::ClaimedExecution.count
-    assert_equal 3, SolidQueue::ReadyExecution.count
+    assert_equal 3, SolidQueue::FailedExecution.count
   end
 
   private

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -6,20 +6,16 @@ class ConfigurationTest < ActiveSupport::TestCase
       SolidQueue::Configuration.new
     end
 
-    assert_equal 2, configuration.processes.count
-
-    assert_equal 1, configuration.workers.count
-    assert_equal 1, configuration.dispatchers.count
-
-    assert_equal [ "*" ], configuration.workers.first.queues
-    assert_equal SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size], configuration.dispatchers.first.batch_size
+    assert_equal 2, configuration.configured_processes.count
+    assert_processes configuration, :worker, 1, queues: [ "*" ]
+    assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
   end
 
   test "read configuration from default file" do
     configuration = SolidQueue::Configuration.new
-    assert 3, configuration.processes.count
-    assert_equal 2, configuration.workers.count
-    assert_equal 1, configuration.dispatchers.count
+    assert 3, configuration.configured_processes.count
+    assert_processes configuration, :worker, 2
+    assert_processes configuration, :dispatcher, 1
   end
 
   test "provide configuration as a hash and fill defaults" do
@@ -28,19 +24,14 @@ class ConfigurationTest < ActiveSupport::TestCase
     config_as_hash = { workers: [ background_worker, background_worker ], dispatchers: [ dispatcher ] }
     configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
 
-    assert_equal 1, configuration.dispatchers.count
-    dispatcher = configuration.dispatchers.first
-    assert_equal SolidQueue::Configuration::DISPATCHER_DEFAULTS[:polling_interval], dispatcher.polling_interval
-    assert_equal SolidQueue::Configuration::DISPATCHER_DEFAULTS[:concurrency_maintenance_interval], dispatcher.concurrency_maintenance.interval
-
-    assert_equal 2, configuration.workers.count
-    assert_equal [ "background" ], configuration.workers.flat_map(&:queues).uniq
-    assert_equal [ 10 ], configuration.workers.map(&:polling_interval).uniq
+    assert_processes configuration, :dispatcher, 1, polling_interval: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:polling_interval], batch_size: 100
+    assert_processes configuration, :worker, 2, queues: [ "background" ], polling_interval: 10
 
     config_as_hash = { workers: [ background_worker, background_worker ] }
     configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
-    assert_empty configuration.dispatchers
-    assert_equal 2, configuration.workers.count
+
+    assert_processes configuration, :dispatcher, 0
+    assert_processes configuration, :worker, 2
   end
 
   test "max number of threads" do
@@ -53,9 +44,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     config_as_hash = { workers: [ background_worker ] }
     configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
 
-    assert_equal 3, configuration.workers.count
-    assert_equal [ "background" ], configuration.workers.flat_map(&:queues).uniq
-    assert_equal [ 10 ], configuration.workers.map(&:polling_interval).uniq
+    assert_equal 3, configuration.configured_processes.count
+    assert_processes configuration, :worker, 3, queues: [ "background" ], polling_interval: 10
   end
 
   test "ignore processes option on async mode" do
@@ -63,8 +53,17 @@ class ConfigurationTest < ActiveSupport::TestCase
     config_as_hash = { workers: [ background_worker ] }
     configuration = SolidQueue::Configuration.new(mode: :async, load_from: config_as_hash)
 
-    assert_equal 1, configuration.workers.count
-    assert_equal [ "background" ], configuration.workers.first.queues
-    assert_equal 10, configuration.workers.first.polling_interval
+    assert_equal 1, configuration.configured_processes.count
+    assert_processes configuration, :worker, 1, queues: [ "background" ], polling_interval: 10
   end
+
+  private
+    def assert_processes(configuration, kind, count, **attributes)
+      processes = configuration.configured_processes.select { |p| p.kind == kind }.map(&:instantiate)
+      assert_equal count, processes.size
+
+      attributes.each do |attr, value|
+        assert_equal value, processes.map { |p| p.public_send(attr) }.first
+      end
+    end
 end

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -20,7 +20,7 @@ class DispatcherTest < ActiveSupport::TestCase
 
     process = SolidQueue::Process.first
     assert_equal "Dispatcher", process.kind
-    assert_equal({ "polling_interval" => 0.1, "batch_size" => 10, "concurrency_maintenance_interval" => 600 }, process.metadata)
+    assert_metadata process, { polling_interval: 0.1, batch_size: 10, concurrency_maintenance_interval: 600 }
   end
 
   test "concurrency maintenance is optional" do
@@ -31,8 +31,7 @@ class DispatcherTest < ActiveSupport::TestCase
 
     process = SolidQueue::Process.first
     assert_equal "Dispatcher", process.kind
-    assert_equal({ "polling_interval" => 0.1, "batch_size" => 10 }, process.metadata)
-
+    assert_metadata process, polling_interval: 0.1, batch_size: 10
   ensure
     no_concurrency_maintenance_dispatcher.stop
   end
@@ -48,8 +47,7 @@ class DispatcherTest < ActiveSupport::TestCase
     process = SolidQueue::Process.first
     assert_equal "Dispatcher", process.kind
 
-    schedule_from_metadata = process.metadata["recurring_schedule"]
-    assert_equal [ "example_task" ], schedule_from_metadata
+    assert_metadata process, recurring_schedule: [ "example_task" ]
   ensure
     with_recurring_schedule.stop
   end
@@ -141,5 +139,11 @@ class DispatcherTest < ActiveSupport::TestCase
       yield
     ensure
       ActiveRecord::Base.logger = old_logger
+    end
+
+    def assert_metadata(process, metadata)
+      metadata.each do |attr, value|
+        assert_equal value, process.metadata[attr.to_s]
+      end
     end
 end

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -88,7 +88,7 @@ class ForkSupervisorTest < ActiveSupport::TestCase
     terminate_process(pid)
   end
 
-  test "release orphaned executions" do
+  test "fail orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
     process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")
 
@@ -114,7 +114,7 @@ class ForkSupervisorTest < ActiveSupport::TestCase
 
     skip_active_record_query_cache do
       assert_equal 0, SolidQueue::ClaimedExecution.count
-      assert_equal 3, SolidQueue::ReadyExecution.count
+      assert_equal 3, SolidQueue::FailedExecution.count
     end
   end
 

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -90,7 +90,7 @@ class ForkSupervisorTest < ActiveSupport::TestCase
 
   test "release orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
-    process = SolidQueue::Process.register(kind: "Worker", pid: 42)
+    process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")
 
     SolidQueue::ReadyExecution.claim("*", 5, process.id)
 

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -51,7 +51,7 @@ class LogSubscriberTest < ActiveSupport::TestCase
   end
 
   test "deregister process" do
-    process = SolidQueue::Process.register(kind: "Worker", pid: 42, hostname: "localhost")
+    process = SolidQueue::Process.register(kind: "Worker", pid: 42, hostname: "localhost", name: "worker-123")
     last_heartbeat_at = process.last_heartbeat_at.iso8601
 
     attach_log_subscriber

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -57,7 +57,7 @@ class LogSubscriberTest < ActiveSupport::TestCase
     attach_log_subscriber
     instrument "deregister_process.solid_queue", process: process, pruned: false, claimed_size: 0
 
-    assert_match_logged :info, "Deregister Worker", "process_id: #{process.id}, pid: 42, hostname: \"localhost\", last_heartbeat_at: \"#{last_heartbeat_at}\", claimed_size: 0, pruned: false"
+    assert_match_logged :info, "Deregister Worker", "process_id: #{process.id}, pid: 42, hostname: \"localhost\", name: \"worker-123\", last_heartbeat_at: \"#{last_heartbeat_at}\", claimed_size: 0, pruned: false"
   end
 
   private

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -19,7 +19,7 @@ class WorkerTest < ActiveSupport::TestCase
 
     process = SolidQueue::Process.first
     assert_equal "Worker", process.kind
-    assert_equal({ "queues" => "background", "polling_interval" => 0.2, "thread_pool_size" => 3 }, process.metadata)
+    assert_metadata process, { queues: "background", polling_interval: 0.2, thread_pool_size: 3 }
   end
 
   test "errors on polling are passed to on_thread_error and re-raised" do
@@ -146,5 +146,11 @@ class WorkerTest < ActiveSupport::TestCase
       yield
     ensure
       ActiveRecord::Base.logger = old_logger
+    end
+
+    def assert_metadata(process, metadata)
+      metadata.each do |attr, value|
+        assert_equal value, process.metadata[attr.to_s]
+      end
     end
 end


### PR DESCRIPTION
This applies to:
- Killed workers that the supervisor detects as dead.
- Reaped workers without a clear exit status.
- Orphaned executions that somehow lost their worker.
- Workers whose heartbeat expired.

To do this easily, since the supervisor doesn't register all workers for efficiency, we need to rely on a new unique identifier that links the supervisor with their configured processes. Since the registration happens after forking, the supervisor doesn't know the registered process IDs of its supervised processes. This unique identifier is a `name` that gets randomly generated when the process is instantiated. This made me realise I was reusing the configured processes object to start new processes, which is quite prone to issues with already created thread pools and stuff like that 😬  Because of this, this PR also changes the approach to have the Configuration object return configured processes that need to be instantiated before starting, and each time create a new object. 