### PR TITLE
Require fugit >= 1.11.1

### DIFF
--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", rails_version
   spec.add_dependency "railties", rails_version
   spec.add_dependency "concurrent-ruby", ">= 1.3.1"
-  spec.add_dependency "fugit", "~> 1.11.0"
+  spec.add_dependency "fugit", "~> 1.11", "> 1.11.1"
 
   spec.add_development_dependency "debug"
   spec.add_development_dependency "mocha"

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", rails_version
   spec.add_dependency "railties", rails_version
   spec.add_dependency "concurrent-ruby", ">= 1.3.1"
-  spec.add_dependency "fugit", "~> 1.11", "> 1.11.1"
+  spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
 
   spec.add_development_dependency "debug"
   spec.add_development_dependency "mocha"


### PR DESCRIPTION
https://github.com/floraison/fugit/issues/104

Prevent Fugit::Nat.parse choking on large input, peg at 256 chars

```ruby
spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
```

Which requires fugit from 1.11.0 to 2.x not included and at least 1.11.1