### PR TITLE
Avoid three-state boolean (TRUE / FALSE / NULL) for `solid_queue_recurring_tasks` `static`

### DIFF
--- a/db/migrate/20240819165045_change_solid_queue_recurring_tasks_static_to_not_null.rb
+++ b/db/migrate/20240819165045_change_solid_queue_recurring_tasks_static_to_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeSolidQueueRecurringTasksStaticToNotNull < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :solid_queue_recurring_tasks, :static, false, true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_19_134516) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_19_165045) do
   create_table "job_results", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name"
     t.string "status"
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_19_134516) do
     t.text "arguments"
     t.string "queue_name"
     t.integer "priority", default: 0
-    t.boolean "static", default: true
+    t.boolean "static", default: true, null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
This ensures the recurring tasks static is always either `TRUE` or `FALSE` (never `NULL`).