### PR TITLE
Support recurring jobs that defer enqueuing to after commit always

### DIFF
--- a/app/models/solid_queue/recurring_execution.rb
+++ b/app/models/solid_queue/recurring_execution.rb
@@ -25,7 +25,7 @@ module SolidQueue
       def record(task_key, run_at, &block)
         transaction do
           block.call.tap do |active_job|
-            if active_job
+            if active_job && active_job.successfully_enqueued?
               create_or_insert!(job_id: active_job.provider_job_id, task_key: task_key, run_at: run_at)
             end
           end


### PR DESCRIPTION
These need to be enqueued within the transaction that creates the recurring execution to avoid duplicate runs. However, if the job is set to `enqueue_after_transaction_commit = :always` or `:default` when we change the default, it won't work because we'll try to create the recurring execution without having actually enqueued the job. With this change, we bypass Active Job's enqueuing and enqueue directly with Solid Queue, running `enqueue` callbacks.