### PR TITLE
Fixed broken rollback migratio in processes' name

### DIFF
--- a/db/migrate/20240813160053_make_name_not_null.rb
+++ b/db/migrate/20240813160053_make_name_not_null.rb
@@ -11,6 +11,6 @@ class MakeNameNotNull < ActiveRecord::Migration[7.1]
 
   def down
     remove_index :solid_queue_processes, [ :name, :supervisor_id ]
-    change_column :solid_queue_processes, :name, :string, null: false
+    change_column :solid_queue_processes, :name, :string, null: true
   end
 end


### PR DESCRIPTION
This is a migration fix added by https://github.com/rails/solid_queue/commit/76d2c0f62e60663407bf0bba384e8d667f9cc3e3.
Since `up` is a change to NOT NULL, `down` must undo it.