### PR TITLE
Improve handling of empty configuration

### DIFF
--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -9,8 +9,12 @@ module SolidQueue
         SolidQueue.supervisor = true
         configuration = Configuration.new(mode: mode, load_from: load_configuration_from)
 
-        klass = mode == :fork ? ForkSupervisor : AsyncSupervisor
-        klass.new(configuration).tap(&:start)
+        if configuration.configured_processes.any?
+          klass = mode == :fork ? ForkSupervisor : AsyncSupervisor
+          klass.new(configuration).tap(&:start)
+        else
+          abort "No workers or processed configured. Exiting..."
+        end
       end
     end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -11,6 +11,14 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
   end
 
+  test "default configuration when config given doesn't include any configuration" do
+    configuration = SolidQueue::Configuration.new(load_from: { random_wrong_key: :random_value })
+
+    assert_equal 2, configuration.configured_processes.count
+    assert_processes configuration, :worker, 1, queues: [ "*" ]
+    assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
+  end
+
   test "read configuration from default file" do
     configuration = SolidQueue::Configuration.new
     assert 3, configuration.configured_processes.count

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -41,6 +41,16 @@ class ForkSupervisorTest < ActiveSupport::TestCase
     assert_no_registered_processes
   end
 
+  test "start with empty configuration" do
+    config_as_hash = { workers: [], dispatchers: [] }
+
+    pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
+    sleep(0.5)
+    assert_no_registered_processes
+
+    assert_not process_exists?(pid)
+  end
+
   test "create and delete pidfile" do
     assert_not File.exist?(@pidfile)
 


### PR DESCRIPTION
Two improvements: 

- Use default configuration when the one given is empty, W¡which happens for example when you have solid queue configuration for an environment but not for others, so you can't find the `workers` and `dispatchers` keys.
- Don't try to start a supervisor on an empty configuration. It leads to weird errors, especially when forking, such as
`Errno::ECHILD` when trying to check on the children status without having forked any children.

I want to improve this with a generic configuration validation step, that would check this and other things, and abort/raise if there are any problems, but this will do for now.

Closes #298 