### PR TITLE
Fix issue when pruning a supervisor and its supervisees via callbacks

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -29,8 +29,9 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     def release_all
       SolidQueue.instrument(:release_many_claimed) do |payload|
         includes(:job).tap do |executions|
-          payload[:size] = executions.size
           executions.each(&:release)
+
+          payload[:size] = executions.size
         end
       end
     end
@@ -38,11 +39,11 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     def fail_all_with(error)
       SolidQueue.instrument(:fail_many_claimed) do |payload|
         includes(:job).tap do |executions|
-          payload[:size] = executions.size
+          executions.each { |execution| execution.failed_with(error) }
+
           payload[:process_ids] = executions.map(&:process_id).uniq
           payload[:job_ids] = executions.map(&:job_id).uniq
-
-          executions.each { |execution| execution.failed_with(error) }
+          payload[:size] = executions.size
         end
       end
     end

--- a/app/models/solid_queue/process/executor.rb
+++ b/app/models/solid_queue/process/executor.rb
@@ -8,12 +8,18 @@ module SolidQueue
       included do
         has_many :claimed_executions
 
-        after_destroy -> { claimed_executions.release_all }, if: :claims_executions?
+        after_destroy :release_all_claimed_executions
       end
 
       def fail_all_claimed_executions_with(error)
         if claims_executions?
           claimed_executions.fail_all_with(error)
+        end
+      end
+
+      def release_all_claimed_executions
+        if claims_executions?
+          claimed_executions.release_all
         end
       end
 

--- a/lib/solid_queue/supervisor/maintenance.rb
+++ b/lib/solid_queue/supervisor/maintenance.rb
@@ -35,7 +35,7 @@ module SolidQueue
 
       def fail_orphaned_executions
         wrap_in_app_executor do
-          SolidQueue::ClaimedExecution.orphaned.fail_all_with(ProcessMissingError.new)
+          ClaimedExecution.orphaned.fail_all_with(ProcessMissingError.new)
         end
       end
   end


### PR DESCRIPTION
This is a follow-up to #277.

In that case, we weren't correctly failing executions as a consequence of the prune because the processes would get deleted via a callback without going through the regular prune. Leave this to the prune itself instead of relying on the callbacks and only deregister supervised processes when not pruning. This also saves a query because we check whether we have a supervisor or not before trying to find supervisees.