### PR TITLE
Bump workflow to latest Ruby from 3.3.4 to 3.3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.3.4]
+        ruby-version: [3.3.5]
         database: [mysql, postgres, sqlite]
     services:
       mysql:


### PR DESCRIPTION
Simply updates workflow to latest Ruby, as a new (every other month) release dropped yesterday, Sept 3rd.

- https://www.ruby-lang.org/en/news/2024/09/03/3-3-5-released/
- https://github.com/ruby/ruby/releases/tag/v3_3_5

Quick follow up to the the following which was ~1 day early it seems. 😅 
- https://github.com/rails/solid_queue/pull/319