### PR TITLE
Update rake task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Solid Queue can be used with SQL databases such as MySQL, PostgreSQL or SQLite, 
 Solid Queue is configured by default in new Rails 8 applications. But if you're running an earlier version, you can add it manually following these steps:
 
 1. `bundle add solid_queue`
-2. `bin/rails solid_queue:install`
+2. `bin/rails solid_queue:install:migrations`
 
 This will configure Solid Queue as the production Active Job backend, create `config/solid_queue.yml`, and create the `db/queue_schema.rb`.
 


### PR DESCRIPTION
There's no:
bin/rails solid_queue:install

in the current version, but presumably this task was changed to:

bin/rails solid_queue:install:migrations

which is a current task name


```sh
bin/rails -T solid_queue
bin/rails solid_queue:dispatch            # start solid_queue dispatcher to enqueue scheduled jobs
bin/rails solid_queue:install:migrations  # Copy migrations from solid_queue to application
bin/rails solid_queue:start               # start solid_queue supervisor to dispatch and process jobs
bin/rails solid_queue:work                # start solid_queue supervisor to process jobs
```