### PR TITLE
Handle scenarios where registered processes disappear outside regular flow

### DIFF
--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -10,9 +10,9 @@ module SolidQueue
       end
 
       class_methods do
-        def prune
+        def prune(excluding: nil)
           SolidQueue.instrument :prune_processes, size: 0 do |payload|
-            prunable.non_blocking_lock.find_in_batches(batch_size: 50) do |batch|
+            prunable.excluding(excluding).non_blocking_lock.find_in_batches(batch_size: 50) do |batch|
               payload[:size] += batch.size
 
               batch.each(&:prune)

--- a/lib/solid_queue/processes/base.rb
+++ b/lib/solid_queue/processes/base.rb
@@ -10,6 +10,7 @@ module SolidQueue
 
       def initialize(*)
         @name = generate_name
+        @stopped = false
       end
 
       def kind
@@ -28,9 +29,17 @@ module SolidQueue
         {}
       end
 
+      def stop
+        @stopped = true
+      end
+
       private
         def generate_name
           [ kind.downcase, SecureRandom.hex(10) ].join("-")
+        end
+
+        def stopped?
+          @stopped
         end
     end
   end

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -53,7 +53,7 @@ module SolidQueue::Processes
       end
 
       def heartbeat
-        process.reload.heartbeat
+        process.with_lock(&:heartbeat)
       rescue ActiveRecord::RecordNotFound
         self.process = nil
         wake_up

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -29,11 +29,11 @@ module SolidQueue::Processes
       end
 
       def deregister
-        process.deregister if registered?
+        process&.deregister
       end
 
       def registered?
-        process&.persisted?
+        process.present?
       end
 
       def launch_heartbeat
@@ -53,7 +53,10 @@ module SolidQueue::Processes
       end
 
       def heartbeat
-        process.heartbeat
+        process.reload.heartbeat
+      rescue ActiveRecord::RecordNotFound
+        self.process = nil
+        wake_up
       end
   end
 end

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -53,7 +53,7 @@ module SolidQueue::Processes
       end
 
       def heartbeat
-        process.with_lock(&:heartbeat)
+        process.with_lock { process.heartbeat }
       rescue ActiveRecord::RecordNotFound
         self.process = nil
         wake_up

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -41,8 +41,12 @@ module SolidQueue::Processes
         end
       end
 
+      def run
+        raise NotImplementedError
+      end
+
       def shutting_down?
-        stopped? || (running_as_fork? && supervisor_went_away?) || finished?
+        stopped? || (running_as_fork? && supervisor_went_away?) || finished? || !registered?
       end
 
       def run

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -17,9 +17,9 @@ module SolidQueue::Processes
     end
 
     def stop
-      @stopped = true
-      wake_up
+      super
 
+      wake_up
       @thread&.join
     end
 
@@ -33,8 +33,6 @@ module SolidQueue::Processes
       def boot
         SolidQueue.instrument(:start_process, process: self) do
           run_callbacks(:boot) do
-            @stopped = false
-
             if running_as_fork?
               register_signal_handlers
               set_procline
@@ -49,10 +47,6 @@ module SolidQueue::Processes
 
       def run
         raise NotImplementedError
-      end
-
-      def stopped?
-        @stopped
       end
 
       def finished?

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -31,8 +31,6 @@ module SolidQueue
       run_start_hooks
 
       start_processes
-
-      launch_heartbeat
       launch_maintenance_task
 
       supervise

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -31,13 +31,15 @@ module SolidQueue
       run_start_hooks
 
       start_processes
+
+      launch_heartbeat
       launch_maintenance_task
 
       supervise
     end
 
     def stop
-      @stopped = true
+      super
       run_stop_hooks
     end
 
@@ -47,7 +49,6 @@ module SolidQueue
       def boot
         SolidQueue.instrument(:start_process, process: self) do
           run_callbacks(:boot) do
-            @stopped = false
             sync_std_streams
           end
         end
@@ -85,10 +86,6 @@ module SolidQueue
 
         configured_processes[pid] = configured_process
         forks[pid] = process_instance
-      end
-
-      def stopped?
-        @stopped
       end
 
       def set_procline

--- a/lib/solid_queue/supervisor/maintenance.rb
+++ b/lib/solid_queue/supervisor/maintenance.rb
@@ -24,7 +24,7 @@ module SolidQueue
       end
 
       def prune_dead_processes
-        wrap_in_app_executor { SolidQueue::Process.prune }
+        wrap_in_app_executor { SolidQueue::Process.prune(excluding: process) }
       end
 
       def fail_orphaned_executions


### PR DESCRIPTION
This is a simple way to mitigate the effects of a computer going to sleep and then coming back to life, with processes with expired heartbeats that are, however, alive. It came up as part of the quest to reproduce another unrelated error in #324. It's not trivial for the supervisor to know whether a process is actually alive or not because the pid might have been reassigned by the OS to a different process. It can't rely on its registered supervisees either because we might be running multiple supervisors. We could possibly check its current forks, whether the `pid` matches, and in that case, skip the pruning, but I'm wary about introducing complicated logic there because the risk is ending up with dead registered processes and locked jobs. 

Since this scenario should happen only in development, I opted for keeping the pruning logic the same (except from preventing the supervisor from pruning itself, as in that case, the supervisor running the pruning is very much alive and running) and just have each process check whether their registered process record is gone when they heartbeat. If it's gone, just stop as if a `TERM` or `INT` signal had been received. If that process was a supervised fork, its supervisor will replace it as soon as it realises it's gone. 

This might be handy in the future as well, to stop a given worker from Mission Control.  

Big thanks to @npezza93 for catching this scenario. 