### PR TITLE
Revamp recurring tasks configuration and management

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 
 APP_RAKEFILE = File.expand_path("test/dummy/Rakefile", __dir__)
@@ -6,3 +8,14 @@ load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 
 require "bundler/gem_tasks"
+
+def databases
+  %w[ mysql postgres sqlite ]
+end
+
+task :test do
+  databases.each do |database|
+    sh("TARGET_DB=#{database} bin/setup")
+    sh("TARGET_DB=#{database} bin/rails test")
+  end
+end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,8 @@
+# Upgrading to version 0.9.x
+This version changes how recurring tasks are configured. Before, they would be defined as part of the _dispatcher_ configuration. Now they've been upgraded to their own configuration file, and a dedicated process (the _scheduler_) to manage them. Check the _Recurring tasks_ section in the `README` to learn how to configure them in detail.
+
+In short, they live now in `config/recurring.yml` (by default) and follow the same format as before when they lived under `dispatchers > recurring_tasks`.
+
 # Upgrading to version 0.8.x
 *IMPORTANT*: This version collapsed all migrations into a single `db/queue_schema.rb`, that will use a separate `queue` database. If you're upgrading from a version < 0.6.0, you need to upgrade to 0.6.0 first, ensure all migrations are up-to-date, and then upgrade further.
 

--- a/app/jobs/solid_queue/recurring_job.rb
+++ b/app/jobs/solid_queue/recurring_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SolidQueue::RecurringJob < ActiveJob::Base
+  queue_as :solid_queue_recurring
+
+  def perform(command)
+    eval(command)
+  end
+end

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -22,7 +22,7 @@ module SolidQueue
           class_name: options[:class],
           arguments: options[:args],
           schedule: options[:schedule],
-          queue_name: options[:queue_name].presence,
+          queue_name: options[:queue].presence,
           priority: options[:priority].presence,
           description: options[:description],
           static: true

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -55,7 +55,7 @@ module SolidQueue
         else
           payload[:other_adapter] = true
 
-          perform_later do |job|
+          perform_later.tap do |job|
             unless job.successfully_enqueued?
               payload[:enqueue_error] = job.enqueue_error&.message
             end
@@ -106,8 +106,10 @@ module SolidQueue
         end
       end
 
-      def perform_later(&block)
-        job_class.set(enqueue_options).perform_later(*arguments_with_kwargs, &block)
+      def perform_later
+        job_class.new(*arguments_with_kwargs).tap do |active_job|
+          active_job.enqueue(enqueue_options)
+        end
       end
 
       def arguments_with_kwargs

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -14,7 +14,7 @@ module SolidQueue
     default_command :start
 
     def start
-      SolidQueue::Supervisor.start(load_configuration_from: options["config_file"])
+      SolidQueue::Supervisor.start(config_file: options["config_file"])
     end
   end
 end

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -14,7 +14,6 @@ module SolidQueue
       desc: "Path to recurring schedule definition",
       banner: "SOLID_QUEUE_RECURRING_SCHEDULE"
 
-    class_option :dispatch_only, type: :boolean, default: false
     class_option :work_only, type: :boolean, default: false
     class_option :skip_recurring, type: :boolean, default: false
 

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -4,7 +4,19 @@ require "thor"
 
 module SolidQueue
   class Cli < Thor
-    class_option :config_file, type: :string, aliases: "-c", default: Configuration::DEFAULT_CONFIG_FILE_PATH, desc: "Path to config file"
+    class_option :config_file, type: :string, aliases: "-c",
+      default: Configuration::DEFAULT_CONFIG_FILE_PATH,
+      desc: "Path to config file",
+      banner: "SOLID_QUEUE_CONFIG"
+
+    class_option :recurring_schedule_file, type: :string,
+      default: Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH,
+      desc: "Path to recurring schedule definition",
+      banner: "SOLID_QUEUE_RECURRING_SCHEDULE"
+
+    class_option :dispatch_only, type: :boolean, default: false
+    class_option :work_only, type: :boolean, default: false
+    class_option :skip_recurring, type: :boolean, default: false
 
     def self.exit_on_failure?
       true
@@ -14,7 +26,7 @@ module SolidQueue
     default_command :start
 
     def start
-      SolidQueue::Supervisor.start(config_file: options["config_file"])
+      SolidQueue::Supervisor.start(**options.symbolize_keys)
     end
   end
 end

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -14,7 +14,6 @@ module SolidQueue
       desc: "Path to recurring schedule definition",
       banner: "SOLID_QUEUE_RECURRING_SCHEDULE"
 
-    class_option :work_only, type: :boolean, default: false
     class_option :skip_recurring, type: :boolean, default: false
 
     def self.exit_on_failure?

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -28,8 +28,8 @@ module SolidQueue
       dispatchers: [ DISPATCHER_DEFAULTS ]
     }
 
-    def initialize(load_from: nil)
-      @raw_config = config_from(load_from)
+    def initialize(config_file: nil, **options)
+      @raw_config = config_from(config_file || options.presence)
     end
 
     def configured_processes

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -19,21 +19,23 @@ module SolidQueue
       batch_size: 500,
       polling_interval: 1,
       concurrency_maintenance: true,
-      concurrency_maintenance_interval: 600,
-      recurring_tasks: []
+      concurrency_maintenance_interval: 600
     }
 
-    DEFAULT_CONFIG = {
-      workers: [ WORKER_DEFAULTS ],
-      dispatchers: [ DISPATCHER_DEFAULTS ]
-    }
+    DEFAULT_CONFIG_FILE_PATH = "config/solid_queue.yml"
+    DEFAULT_RECURRING_SCHEDULE_FILE_PATH = "config/recurring.yml"
 
-    def initialize(config_file: nil, **options)
-      @raw_config = config_from(config_file || options.presence)
+    def initialize(**options)
+      @options = options.with_defaults(default_options)
     end
 
     def configured_processes
-      dispatchers + workers
+      case
+      when only_work?     then workers
+      when only_dispatch? then dispatchers
+      else
+        dispatchers + workers
+      end
     end
 
     def max_number_of_threads
@@ -42,9 +44,29 @@ module SolidQueue
     end
 
     private
-      attr_reader :raw_config
+      attr_reader :options
 
-      DEFAULT_CONFIG_FILE_PATH = "config/solid_queue.yml"
+      def default_options
+        {
+          config_file: Rails.root.join(ENV["SOLID_QUEUE_CONFIG"] || DEFAULT_CONFIG_FILE_PATH),
+          recurring_schedule_file: Rails.root.join(ENV["SOLID_QUEUE_RECURRING_SCHEDULE"] || DEFAULT_RECURRING_SCHEDULE_FILE_PATH),
+          only_work: false,
+          only_dispatch: false,
+          skip_recurring: false
+        }
+      end
+
+      def only_work?
+        options[:only_work]
+      end
+
+      def only_dispatch?
+        options[:only_dispatch]
+      end
+
+      def skip_recurring_tasks?
+        options[:skip_recurring] || only_work?
+      end
 
       def workers
         workers_options.flat_map do |worker_options|
@@ -55,39 +77,64 @@ module SolidQueue
 
       def dispatchers
         dispatchers_options.map do |dispatcher_options|
-          recurring_tasks = parse_recurring_tasks dispatcher_options[:recurring_tasks]
-          Process.new :dispatcher, dispatcher_options.merge(recurring_tasks: recurring_tasks).with_defaults(DISPATCHER_DEFAULTS)
-        end
-      end
-
-      def config_from(file_or_hash, env: Rails.env)
-        load_config_from(file_or_hash).then do |config|
-          config = config[env.to_sym] ? config[env.to_sym] : config
-          if (config.keys & DEFAULT_CONFIG.keys).any? then config
-          else
-            DEFAULT_CONFIG
-          end
+          Process.new :dispatcher, dispatcher_options.with_defaults(DISPATCHER_DEFAULTS)
         end
       end
 
       def workers_options
-        @workers_options ||= options_from_raw_config(:workers)
+        @workers_options ||= processes_config.fetch(:workers, [])
           .map { |options| options.dup.symbolize_keys }
       end
 
       def dispatchers_options
-        @dispatchers_options ||= options_from_raw_config(:dispatchers)
+        @dispatchers_options ||= processes_config.fetch(:dispatchers, [])
           .map { |options| options.dup.symbolize_keys }
+          .then { |options| with_recurring_tasks(options) }
       end
 
-      def options_from_raw_config(key)
-        Array(raw_config[key])
+      def with_recurring_tasks(options)
+        if !skip_recurring_tasks? && recurring_tasks.any?
+          options.sort_by! { |attrs| attrs[:polling_interval] }
+
+          if least_busy_dispatcher = options.pop
+            least_busy_dispatcher[:recurring_tasks] = recurring_tasks
+            options.push(least_busy_dispatcher)
+          else
+            [ DISPATCHER_DEFAULTS.merge(recurring_tasks: recurring_tasks) ]
+          end
+        else
+          options
+        end
       end
 
-      def parse_recurring_tasks(tasks)
-        Array(tasks).map do |id, options|
+      def recurring_tasks
+        @recurring_tasks ||= recurring_tasks_config.map do |id, options|
           RecurringTask.from_configuration(id, **options)
         end.select(&:valid?)
+      end
+
+      def processes_config
+        @processes_config ||= config_from \
+          options.slice(:workers, :dispatchers).presence || options[:config_file],
+          keys: [ :workers, :dispatchers ],
+          fallback: { workers: [ WORKER_DEFAULTS ], dispatchers: [ DISPATCHER_DEFAULTS ] }
+      end
+
+      def recurring_tasks_config
+        @recurring_tasks ||= config_from options[:recurring_schedule_file]
+      end
+
+
+      def config_from(file_or_hash, keys: [], fallback: {}, env: Rails.env)
+        load_config_from(file_or_hash).then do |config|
+          config = config[env.to_sym] ? config[env.to_sym] : config
+          config = config.slice(*keys) if keys.any?
+
+          if config.empty? then fallback
+          else
+            config
+          end
+        end
       end
 
       def load_config_from(file_or_hash)
@@ -97,21 +144,9 @@ module SolidQueue
         when Pathname, String
           load_config_from_file Pathname.new(file_or_hash)
         when NilClass
-          load_config_from_env_location || load_config_from_default_location
+          {}
         else
           raise "Solid Queue cannot be initialized with #{file_or_hash.inspect}"
-        end
-      end
-
-      def load_config_from_env_location
-        if ENV["SOLID_QUEUE_CONFIG"].present?
-          load_config_from_file Rails.root.join(ENV["SOLID_QUEUE_CONFIG"])
-        end
-      end
-
-      def load_config_from_default_location
-        Rails.root.join(DEFAULT_CONFIG_FILE_PATH).then do |config_file|
-          config_file.exist? ? load_config_from_file(config_file) : {}
         end
       end
 
@@ -119,7 +154,7 @@ module SolidQueue
         if file.exist?
           ActiveSupport::ConfigurationFile.parse(file).deep_symbolize_keys
         else
-          raise "Configuration file for Solid Queue not found in #{file}"
+          {}
         end
       end
   end

--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -2,10 +2,10 @@
 
 module SolidQueue
   class Dispatcher < Processes::Poller
-    attr_accessor :batch_size, :concurrency_maintenance, :recurring_schedule
+    attr_accessor :batch_size, :concurrency_maintenance
 
-    after_boot :start_concurrency_maintenance, :schedule_recurring_tasks
-    before_shutdown :stop_concurrency_maintenance, :unschedule_recurring_tasks
+    after_boot :start_concurrency_maintenance
+    before_shutdown :stop_concurrency_maintenance
 
     def initialize(**options)
       options = options.dup.with_defaults(SolidQueue::Configuration::DISPATCHER_DEFAULTS)
@@ -13,13 +13,12 @@ module SolidQueue
       @batch_size = options[:batch_size]
 
       @concurrency_maintenance = ConcurrencyMaintenance.new(options[:concurrency_maintenance_interval], options[:batch_size]) if options[:concurrency_maintenance]
-      @recurring_schedule = RecurringSchedule.new(options[:recurring_tasks])
 
       super(**options)
     end
 
     def metadata
-      super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval, recurring_schedule: recurring_schedule.task_keys.presence)
+      super.merge(batch_size: batch_size, concurrency_maintenance_interval: concurrency_maintenance&.interval)
     end
 
     private

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -94,7 +94,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     if error = event.payload[:error]
       warn formatted_event(event, action: "Error registering #{process_kind}", **attributes.merge(error: formatted_error(error)))
     else
-      info formatted_event(event, action: "Register #{process_kind}", **attributes)
+      debug formatted_event(event, action: "Register #{process_kind}", **attributes)
     end
   end
 
@@ -114,7 +114,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     if error = event.payload[:error]
       warn formatted_event(event, action: "Error deregistering #{process.kind}", **attributes.merge(error: formatted_error(error)))
     else
-      info formatted_event(event, action: "Deregister #{process.kind}", **attributes)
+      debug formatted_event(event, action: "Deregister #{process.kind}", **attributes)
     end
   end
 

--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -41,9 +41,6 @@ module SolidQueue::Processes
         raise NotImplementedError
       end
 
-      def shutdown
-      end
-
       def with_polling_volume
         SolidQueue.instrument(:polling) do
           if SolidQueue.silence_polling? && ActiveRecord::Base.logger

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -18,7 +18,7 @@ module SolidQueue::Processes
 
     def stop
       @stopped = true
-      wake_up if running_async?
+      wake_up
 
       @thread&.join
     end

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -18,6 +18,8 @@ module SolidQueue::Processes
 
     def stop
       @stopped = true
+      wake_up if running_async?
+
       @thread&.join
     end
 
@@ -59,6 +61,9 @@ module SolidQueue::Processes
 
       def all_work_completed?
         false
+      end
+
+      def shutdown
       end
 
       def set_procline

--- a/lib/solid_queue/processes/supervised.rb
+++ b/lib/solid_queue/processes/supervised.rb
@@ -29,7 +29,6 @@ module SolidQueue::Processes
         %w[ INT TERM ].each do |signal|
           trap(signal) do
             stop
-            interrupt
           end
         end
 

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -20,7 +20,7 @@ module SolidQueue
     end
 
     private
-      SLEEP_INTERVAL = 300 # Right now it doesn't matter, can be set to 1 in the future for dynamic tasks
+      SLEEP_INTERVAL = 60 # Right now it doesn't matter, can be set to 1 in the future for dynamic tasks
 
       def run
         loop do

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SolidQueue
+  class Scheduler < Processes::Base
+    include Processes::Runnable
+
+    attr_accessor :recurring_schedule
+
+    after_boot :schedule_recurring_tasks
+    before_shutdown :unschedule_recurring_tasks
+
+    def initialize(recurring_tasks:, **options)
+      @recurring_schedule = RecurringSchedule.new(recurring_tasks)
+
+      super(**options)
+    end
+
+    def metadata
+      super.merge(recurring_schedule: recurring_schedule.task_keys.presence)
+    end
+
+    private
+      SLEEP_INTERVAL = 300 # Right now it doesn't matter, can be set to 1 in the future for dynamic tasks
+
+      def run
+        loop do
+          break if shutting_down?
+
+          interruptible_sleep(SLEEP_INTERVAL)
+        end
+      ensure
+        SolidQueue.instrument(:shutdown_process, process: self) do
+          run_callbacks(:shutdown) { shutdown }
+        end
+      end
+
+      def schedule_recurring_tasks
+        recurring_schedule.schedule_tasks
+      end
+
+      def unschedule_recurring_tasks
+        recurring_schedule.unschedule_tasks
+      end
+
+      def all_work_completed?
+        recurring_schedule.empty?
+      end
+
+      def set_procline
+        procline "scheduling #{recurring_schedule.task_keys.join(",")}"
+      end
+  end
+end

--- a/lib/solid_queue/scheduler/recurring_schedule.rb
+++ b/lib/solid_queue/scheduler/recurring_schedule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidQueue
-  class Dispatcher::RecurringSchedule
+  class Scheduler::RecurringSchedule
     include AppExecutor
 
     attr_reader :configured_tasks, :scheduled_tasks

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -6,9 +6,9 @@ module SolidQueue
     include Maintenance, Signals, Pidfiled
 
     class << self
-      def start(load_configuration_from: nil)
+      def start(**options)
         SolidQueue.supervisor = true
-        configuration = Configuration.new(load_from: load_configuration_from)
+        configuration = Configuration.new(**options)
 
         if configuration.configured_processes.any?
           new(configuration).tap(&:start)

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -11,11 +11,15 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
 
   spec.post_install_message = <<~MESSAGE
-    Upgrading to Solid Queue 0.8.0 from < 0.6.0? You need to upgrade to 0.6.0 first. Check https://github.com/rails/solid_queue/blob/main/UPGRADING.md
-    for upgrade instructions.
+    Upgrading to Solid Queue 0.9.0? There are some breaking changes about how recurring tasks are configured.
+
+    Upgrading to Solid Queue 0.8.0 from < 0.6.0? You need to upgrade to 0.6.0 first.
 
     Upgrading to Solid Queue 0.4.x, 0.5.x, 0.6.x or 0.7.x? There are some breaking changes about how Solid Queue is started,
     configuration and new migrations.
+
+    --> Check https://github.com/rails/solid_queue/blob/main/UPGRADING.md
+    for upgrade instructions.
   MESSAGE
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/test/dummy/config/alternative_configuration.yml
+++ b/test/dummy/config/alternative_configuration.yml
@@ -1,0 +1,12 @@
+default: &default
+  workers:
+    <% 3.times do |i| %>
+    - queues: queue_<%= i + 1 %>
+      threads: <%= i + 1 %>
+    <% end %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default

--- a/test/dummy/config/empty_configuration.yml
+++ b/test/dummy/config/empty_configuration.yml
@@ -1,0 +1,7 @@
+default: &default
+
+development:
+  <<: *default
+
+test:
+  <<: *default

--- a/test/dummy/config/empty_configuration.yml
+++ b/test/dummy/config/empty_configuration.yml
@@ -1,7 +1,3 @@
-default: &default
+development: []
 
-development:
-  <<: *default
-
-test:
-  <<: *default
+test: []

--- a/test/dummy/config/invalid_configuration.yml
+++ b/test/dummy/config/invalid_configuration.yml
@@ -1,0 +1,1 @@
+random_wrong_key: random_value

--- a/test/dummy/config/recurring.yml
+++ b/test/dummy/config/recurring.yml
@@ -1,0 +1,4 @@
+periodic_store_result:
+  class: StoreResultJob
+  args: [ 42, { status: "custom_status" } ]
+  schedule: every second

--- a/test/dummy/config/recurring.yml
+++ b/test/dummy/config/recurring.yml
@@ -1,4 +1,5 @@
 periodic_store_result:
   class: StoreResultJob
+  queue: default
   args: [ 42, { status: "custom_status" } ]
   schedule: every second

--- a/test/dummy/config/solid_queue.yml
+++ b/test/dummy/config/solid_queue.yml
@@ -7,11 +7,6 @@ default: &default
   dispatchers:
     - polling_interval: 1
       batch_size: 500
-      recurring_tasks:
-        periodic_store_result:
-          class: StoreResultJob
-          args: [ 42, { status: "custom_status" } ]
-          schedule: every second
 
 development:
   <<: *default

--- a/test/integration/concurrency_controls_test.rb
+++ b/test/integration/concurrency_controls_test.rb
@@ -11,7 +11,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
     default_worker = { queues: "default", polling_interval: 0.1, processes: 3, threads: 2 }
     dispatcher = { polling_interval: 0.1, batch_size: 200, concurrency_maintenance_interval: 1 }
 
-    @pid = run_supervisor_as_fork(load_configuration_from: { workers: [ default_worker ], dispatchers: [ dispatcher ] })
+    @pid = run_supervisor_as_fork(workers: [ default_worker ], dispatchers: [ dispatcher ])
 
     wait_for_registered_processes(5, timeout: 0.5.second) # 3 workers working the default queue + dispatcher + supervisor
   end

--- a/test/integration/lifecycle_hooks_test.rb
+++ b/test/integration/lifecycle_hooks_test.rb
@@ -12,7 +12,7 @@ class LifecycleHooksTest < ActiveSupport::TestCase
     SolidQueue.on_worker_start { JobResult.create!(status: :hook_called, value: :worker_start) }
     SolidQueue.on_worker_stop { JobResult.create!(status: :hook_called, value: :worker_stop) }
 
-    pid = run_supervisor_as_fork(load_configuration_from: { workers: [ { queues: "*" } ] })
+    pid = run_supervisor_as_fork(workers: [ { queues: "*" } ])
     wait_for_registered_processes(4)
 
     terminate_process(pid)

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -6,8 +6,7 @@ class ProcessesLifecycleTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
   setup do
-    config_as_hash = { workers: [ { queues: :background }, { queues: :default, threads: 5 } ], dispatchers: [] }
-    @pid = run_supervisor_as_fork(config_as_hash)
+    @pid = run_supervisor_as_fork(workers: [ { queues: :background }, { queues: :default, threads: 5 } ])
 
     wait_for_registered_processes(3, timeout: 3.second)
     assert_registered_workers_for(:background, :default, supervisor_pid: @pid)

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -7,7 +7,7 @@ class ProcessesLifecycleTest < ActiveSupport::TestCase
 
   setup do
     config_as_hash = { workers: [ { queues: :background }, { queues: :default, threads: 5 } ], dispatchers: [] }
-    @pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
+    @pid = run_supervisor_as_fork(config_as_hash)
 
     wait_for_registered_processes(3, timeout: 3.second)
     assert_registered_workers_for(:background, :default, supervisor_pid: @pid)

--- a/test/integration/puma/plugin_test.rb
+++ b/test/integration/puma/plugin_test.rb
@@ -19,7 +19,7 @@ class PluginTest < ActiveSupport::TestCase
         exec(*cmd)
       end
     end
-    wait_for_registered_processes(4, timeout: 3.second)
+    wait_for_registered_processes 5, timeout: 3.second
   end
 
   teardown do
@@ -38,7 +38,7 @@ class PluginTest < ActiveSupport::TestCase
     signal_process(@pid, :SIGUSR2)
     # Ensure the restart finishes before we try to continue with the test
     wait_for_registered_processes(0, timeout: 3.second)
-    wait_for_registered_processes(4, timeout: 3.second)
+    wait_for_registered_processes(5, timeout: 3.second)
 
     StoreResultJob.perform_later(:puma_plugin)
     wait_for_jobs_to_finish_for(2.seconds)

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -130,7 +130,7 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
   end
 
   test "task with custom queue and priority" do
-    task = recurring_task_with(class_name: "JobWithoutArguments", queue_name: "my_new_queue", priority: 4)
+    task = recurring_task_with(class_name: "JobWithoutArguments", queue: "my_new_queue", priority: 4)
     enqueue_and_assert_performed_with_result task, "job_without_arguments"
 
     job = SolidQueue::Job.last
@@ -170,7 +170,7 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
       assert_equal result, JobBuffer.last_value
     end
 
-    def recurring_task_with(class_name:, schedule: "every hour", args: nil, **options)
-      SolidQueue::RecurringTask.new(key: "task-id", class_name: "SolidQueue::RecurringTaskTest::#{class_name}", schedule: schedule, arguments: args, **options)
+    def recurring_task_with(class_name:, **options)
+      SolidQueue::RecurringTask.from_configuration("task-id", class: "SolidQueue::RecurringTaskTest::#{class_name}", **options.with_defaults(schedule: "every hour"))
     end
 end

--- a/test/test_helpers/processes_test_helper.rb
+++ b/test/test_helpers/processes_test_helper.rb
@@ -3,7 +3,7 @@ module ProcessesTestHelper
 
   def run_supervisor_as_fork(**options)
     fork do
-      SolidQueue::Supervisor.start(**options)
+      SolidQueue::Supervisor.start(**options.with_defaults(skip_recurring: true))
     end
   end
 
@@ -35,6 +35,12 @@ module ProcessesTestHelper
           assert_nil process.public_send(attr)
         end
       end
+    end
+  end
+
+  def assert_metadata(process, metadata)
+    metadata.each do |attr, value|
+      assert_equal value, process.metadata[attr.to_s]
     end
   end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -7,23 +7,23 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
 
     assert_equal 2, configuration.configured_processes.count
-    assert_processes configuration, :worker, 1, queues: [ "*" ]
+    assert_processes configuration, :worker, 1, queues: "*"
     assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
   end
 
   test "default configuration when config given doesn't include any configuration" do
-    configuration = SolidQueue::Configuration.new(load_from: { random_wrong_key: :random_value })
+    configuration = SolidQueue::Configuration.new(random_wrong_key: :random_value)
 
     assert_equal 2, configuration.configured_processes.count
-    assert_processes configuration, :worker, 1, queues: [ "*" ]
+    assert_processes configuration, :worker, 1, queues: "*"
     assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
   end
 
   test "default configuration when config given is empty" do
-    configuration = SolidQueue::Configuration.new(load_from: {})
+    configuration = SolidQueue::Configuration.new(config_file: Rails.root.join("config/empty_configuration.yml"))
 
     assert_equal 2, configuration.configured_processes.count
-    assert_processes configuration, :worker, 1, queues: [ "*" ]
+    assert_processes configuration, :worker, 1, queues: "*"
     assert_processes configuration, :dispatcher, 1, batch_size: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size]
   end
 
@@ -34,17 +34,22 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_processes configuration, :dispatcher, 1
   end
 
+  test "read configuration from provided file" do
+    configuration = SolidQueue::Configuration.new(config_file: Rails.root.join("config/alternative_configuration.yml"))
+
+    assert 3, configuration.configured_processes.count
+    assert_processes configuration, :worker, 3, processes: 1, polling_interval: 0.1, queues: %w[ queue_1 queue_2 queue_3 ], threads: [ 1, 2, 3 ]
+  end
+
   test "provide configuration as a hash and fill defaults" do
     background_worker = { queues: "background", polling_interval: 10 }
     dispatcher = { batch_size: 100 }
-    config_as_hash = { workers: [ background_worker, background_worker ], dispatchers: [ dispatcher ] }
-    configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
+    configuration = SolidQueue::Configuration.new(workers: [ background_worker, background_worker ], dispatchers: [ dispatcher ])
 
     assert_processes configuration, :dispatcher, 1, polling_interval: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:polling_interval], batch_size: 100
-    assert_processes configuration, :worker, 2, queues: [ "background" ], polling_interval: 10
+    assert_processes configuration, :worker, 2, queues: "background", polling_interval: 10
 
-    config_as_hash = { workers: [ background_worker, background_worker ] }
-    configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
+    configuration = SolidQueue::Configuration.new(workers: [ background_worker, background_worker ])
 
     assert_processes configuration, :dispatcher, 0
     assert_processes configuration, :worker, 2
@@ -57,20 +62,24 @@ class ConfigurationTest < ActiveSupport::TestCase
 
   test "mulitple workers with the same configuration" do
     background_worker = { queues: "background", polling_interval: 10, processes: 3 }
-    config_as_hash = { workers: [ background_worker ] }
-    configuration = SolidQueue::Configuration.new(load_from: config_as_hash)
+    configuration = SolidQueue::Configuration.new(workers: [ background_worker ])
 
     assert_equal 3, configuration.configured_processes.count
-    assert_processes configuration, :worker, 3, queues: [ "background" ], polling_interval: 10
+    assert_processes configuration, :worker, 3, queues: "background", polling_interval: 10
   end
 
   private
     def assert_processes(configuration, kind, count, **attributes)
-      processes = configuration.configured_processes.select { |p| p.kind == kind }.map(&:instantiate)
+      processes = configuration.configured_processes.select { |p| p.kind == kind }
       assert_equal count, processes.size
 
-      attributes.each do |attr, value|
-        assert_equal value, processes.map { |p| p.public_send(attr) }.first
+      attributes.each do |attr, expected_value|
+        value = processes.map { |p| p.attributes.fetch(attr) }
+        unless expected_value.is_a?(Array)
+          value = value.first
+        end
+
+        assert_equal expected_value, value
       end
     end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -2,9 +2,7 @@ require "test_helper"
 
 class ConfigurationTest < ActiveSupport::TestCase
   test "default configuration to process all queues and dispatch" do
-    configuration = stub_const(SolidQueue::Configuration, :DEFAULT_CONFIG_FILE_PATH, "non/existent/path") do
-      SolidQueue::Configuration.new
-    end
+    configuration = SolidQueue::Configuration.new(config_file: nil)
 
     assert_equal 2, configuration.configured_processes.count
     assert_processes configuration, :worker, 1, queues: "*"
@@ -12,7 +10,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "default configuration when config given doesn't include any configuration" do
-    configuration = SolidQueue::Configuration.new(random_wrong_key: :random_value)
+    configuration = SolidQueue::Configuration.new(config_file: config_file_path(:invalid_configuration))
 
     assert_equal 2, configuration.configured_processes.count
     assert_processes configuration, :worker, 1, queues: "*"
@@ -20,7 +18,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "default configuration when config given is empty" do
-    configuration = SolidQueue::Configuration.new(config_file: Rails.root.join("config/empty_configuration.yml"))
+    configuration = SolidQueue::Configuration.new(config_file: config_file_path(:empty_configuration))
 
     assert_equal 2, configuration.configured_processes.count
     assert_processes configuration, :worker, 1, queues: "*"
@@ -35,7 +33,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "read configuration from provided file" do
-    configuration = SolidQueue::Configuration.new(config_file: Rails.root.join("config/alternative_configuration.yml"))
+    configuration = SolidQueue::Configuration.new(config_file: config_file_path(:alternative_configuration), only_work: true)
 
     assert 3, configuration.configured_processes.count
     assert_processes configuration, :worker, 3, processes: 1, polling_interval: 0.1, queues: %w[ queue_1 queue_2 queue_3 ], threads: [ 1, 2, 3 ]
@@ -49,7 +47,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_processes configuration, :dispatcher, 1, polling_interval: SolidQueue::Configuration::DISPATCHER_DEFAULTS[:polling_interval], batch_size: 100
     assert_processes configuration, :worker, 2, queues: "background", polling_interval: 10
 
-    configuration = SolidQueue::Configuration.new(workers: [ background_worker, background_worker ])
+    configuration = SolidQueue::Configuration.new(workers: [ background_worker, background_worker ], skip_recurring: true)
 
     assert_processes configuration, :dispatcher, 0
     assert_processes configuration, :worker, 2
@@ -64,8 +62,42 @@ class ConfigurationTest < ActiveSupport::TestCase
     background_worker = { queues: "background", polling_interval: 10, processes: 3 }
     configuration = SolidQueue::Configuration.new(workers: [ background_worker ])
 
-    assert_equal 3, configuration.configured_processes.count
     assert_processes configuration, :worker, 3, queues: "background", polling_interval: 10
+  end
+
+  test "recurring tasks configuration with one dispatcher" do
+    configuration = SolidQueue::Configuration.new(dispatchers: [ { polling_interval: 0.1 } ])
+
+    assert_processes configuration, :dispatcher, 1, polling_interval: 0.1
+
+    dispatcher = configuration.configured_processes.first.instantiate
+    assert_has_recurring_task dispatcher, key: "periodic_store_result", class_name: "StoreResultJob", schedule: "every second"
+  end
+
+  test "recurring tasks configuration with no dispatchers uses a default dispatcher" do
+    configuration = SolidQueue::Configuration.new(dispatchers: [])
+
+    assert_processes configuration, :dispatcher, 1, polling_interval: 1
+
+    dispatcher = configuration.configured_processes.first.instantiate
+    assert_has_recurring_task dispatcher, key: "periodic_store_result", class_name: "StoreResultJob", schedule: "every second"
+  end
+
+  test "recurring tasks configuration with multiple dispatchers uses the least busy one" do
+    configuration = SolidQueue::Configuration.new(dispatchers: [ { polling_interval: 0.1 }, { polling_interval: 0.4 }, { polling_interval: 0.2 } ])
+
+    assert_processes configuration, :dispatcher, 3, polling_interval: [ 0.1, 0.2, 0.4 ] # sorted by polling interval
+
+    dispatcher = configuration.configured_processes.last.instantiate
+    assert_has_recurring_task dispatcher, key: "periodic_store_result", class_name: "StoreResultJob", schedule: "every second"
+
+    dispatchers_without_recurring_tasks = configuration.configured_processes.first(2)
+    assert_nil dispatchers_without_recurring_tasks.map { |d| d.attributes[:recurring_tasks] }.uniq.first
+  end
+
+  test "no recurring tasks configuration when explicitly excluded" do
+    configuration = SolidQueue::Configuration.new(dispatchers: [ { polling_interval: 0.1 } ], skip_recurring: true)
+    assert_processes configuration, :dispatcher, 1, polling_interval: 0.1, recurring_tasks: nil
   end
 
   private
@@ -74,12 +106,29 @@ class ConfigurationTest < ActiveSupport::TestCase
       assert_equal count, processes.size
 
       attributes.each do |attr, expected_value|
-        value = processes.map { |p| p.attributes.fetch(attr) }
+        value = processes.map { |p| p.attributes[attr] }
         unless expected_value.is_a?(Array)
           value = value.first
         end
 
-        assert_equal expected_value, value
+        if expected_value.nil?
+          assert_nil value
+        else
+          assert_equal expected_value, value
+        end
       end
+    end
+
+    def assert_has_recurring_task(dispatcher, key:, **attributes)
+      assert_equal 1, dispatcher.recurring_schedule.configured_tasks.count
+      task = dispatcher.recurring_schedule.configured_tasks.detect { |t| t.key == key }
+
+      attributes.each do |attr, value|
+        assert_equal value, task.public_send(attr)
+      end
+    end
+
+    def config_file_path(name)
+      Rails.root.join("config/#{name}.yml")
     end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -111,11 +111,7 @@ class ConfigurationTest < ActiveSupport::TestCase
           value = value.first
         end
 
-        if expected_value.nil?
-          assert_nil value
-        else
-          assert_equal expected_value, value
-        end
+        assert_equal_value expected_value, value
       end
     end
 
@@ -124,7 +120,15 @@ class ConfigurationTest < ActiveSupport::TestCase
       task = dispatcher.recurring_schedule.configured_tasks.detect { |t| t.key == key }
 
       attributes.each do |attr, value|
-        assert_equal value, task.public_send(attr)
+        assert_equal_value value, task.public_send(attr)
+      end
+    end
+
+    def assert_equal_value(expected_value, value)
+      if expected_value.nil?
+        assert_nil value
+      else
+        assert_equal expected_value, value
       end
     end
 

--- a/test/unit/log_subscriber_test.rb
+++ b/test/unit/log_subscriber_test.rb
@@ -57,7 +57,7 @@ class LogSubscriberTest < ActiveSupport::TestCase
     attach_log_subscriber
     instrument "deregister_process.solid_queue", process: process, pruned: false, claimed_size: 0
 
-    assert_match_logged :info, "Deregister Worker", "process_id: #{process.id}, pid: 42, hostname: \"localhost\", name: \"worker-123\", last_heartbeat_at: \"#{last_heartbeat_at}\", claimed_size: 0, pruned: false"
+    assert_match_logged :debug, "Deregister Worker", "process_id: #{process.id}, pid: 42, hostname: \"localhost\", name: \"worker-123\", last_heartbeat_at: \"#{last_heartbeat_at}\", claimed_size: 0, pruned: false"
   end
 
   private

--- a/test/unit/scheduler_test.rb
+++ b/test/unit/scheduler_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class SchedulerTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  test "recurring schedule" do
+    recurring_tasks = { example_task: { class: "AddToBufferJob", schedule: "every hour", args: 42 } }
+    scheduler = SolidQueue::Scheduler.new(recurring_tasks: recurring_tasks).tap(&:start)
+
+    wait_for_registered_processes(1, timeout: 1.second)
+
+    process = SolidQueue::Process.first
+    assert_equal "Scheduler", process.kind
+
+    assert_metadata process, recurring_schedule: [ "example_task" ]
+  ensure
+    scheduler.stop
+  end
+
+  test "run more than one instance of the dispatcher with recurring tasks" do
+    recurring_tasks = { example_task: { class: "AddToBufferJob", schedule: "every second", args: 42 } }
+    schedulers = 2.times.collect do
+      SolidQueue::Scheduler.new(recurring_tasks: recurring_tasks)
+    end
+
+    schedulers.each(&:start)
+    sleep 2
+    schedulers.each(&:stop)
+
+    assert_equal SolidQueue::Job.count, SolidQueue::RecurringExecution.count
+    run_at_times = SolidQueue::RecurringExecution.all.map(&:run_at).sort
+    0.upto(run_at_times.length - 2) do |i|
+      assert_equal 1, run_at_times[i + 1] - run_at_times[i]
+    end
+  end
+end

--- a/test/unit/scheduler_test.rb
+++ b/test/unit/scheduler_test.rb
@@ -17,7 +17,7 @@ class SchedulerTest < ActiveSupport::TestCase
     scheduler.stop
   end
 
-  test "run more than one instance of the dispatcher with recurring tasks" do
+  test "run more than one instance of the scheduler with recurring tasks" do
     recurring_tasks = { example_task: { class: "AddToBufferJob", schedule: "every second", args: 42 } }
     schedulers = 2.times.collect do
       SolidQueue::Scheduler.new(recurring_tasks: recurring_tasks)

--- a/test/unit/supervisor_test.rb
+++ b/test/unit/supervisor_test.rb
@@ -29,7 +29,7 @@ class SupervisorTest < ActiveSupport::TestCase
 
   test "start with provided configuration" do
     config_as_hash = { workers: [], dispatchers: [ { batch_size: 100 } ] }
-    pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
+    pid = run_supervisor_as_fork(config_as_hash)
     wait_for_registered_processes(2, timeout: 2) # supervisor + dispatcher
 
     assert_registered_supervisor(pid)
@@ -44,7 +44,7 @@ class SupervisorTest < ActiveSupport::TestCase
   test "start with empty configuration" do
     config_as_hash = { workers: [], dispatchers: [] }
 
-    pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
+    pid = run_supervisor_as_fork(config_as_hash)
     sleep(0.5)
     assert_no_registered_processes
 
@@ -116,7 +116,7 @@ class SupervisorTest < ActiveSupport::TestCase
       workers: [ { queues: "background", polling_interval: 10, processes: 2 } ],
       dispatchers: []
     }
-    pid = run_supervisor_as_fork(load_configuration_from: config_as_hash)
+    pid = run_supervisor_as_fork(config_as_hash)
     wait_for_registered_processes(3)
     assert_registered_supervisor(pid)
 

--- a/test/unit/supervisor_test.rb
+++ b/test/unit/supervisor_test.rb
@@ -28,8 +28,7 @@ class SupervisorTest < ActiveSupport::TestCase
   end
 
   test "start with provided configuration" do
-    config_as_hash = { workers: [], dispatchers: [ { batch_size: 100 } ] }
-    pid = run_supervisor_as_fork(config_as_hash)
+    pid = run_supervisor_as_fork(dispatchers: [ { batch_size: 100 } ])
     wait_for_registered_processes(2, timeout: 2) # supervisor + dispatcher
 
     assert_registered_supervisor(pid)
@@ -42,9 +41,7 @@ class SupervisorTest < ActiveSupport::TestCase
   end
 
   test "start with empty configuration" do
-    config_as_hash = { workers: [], dispatchers: [] }
-
-    pid = run_supervisor_as_fork(config_as_hash)
+    pid = run_supervisor_as_fork(workers: [], dispatchers: [])
     sleep(0.5)
     assert_no_registered_processes
 
@@ -112,11 +109,7 @@ class SupervisorTest < ActiveSupport::TestCase
     # Simnulate orphaned executions by just wiping the claiming process
     process.delete
 
-    config_as_hash = {
-      workers: [ { queues: "background", polling_interval: 10, processes: 2 } ],
-      dispatchers: []
-    }
-    pid = run_supervisor_as_fork(config_as_hash)
+    pid = run_supervisor_as_fork(workers: [ { queues: "background", polling_interval: 10, processes: 2 } ])
     wait_for_registered_processes(3)
     assert_registered_supervisor(pid)
 

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -147,10 +147,4 @@ class WorkerTest < ActiveSupport::TestCase
     ensure
       ActiveRecord::Base.logger = old_logger
     end
-
-    def assert_metadata(process, metadata)
-      metadata.each do |attr, value|
-        assert_equal value, process.metadata[attr.to_s]
-      end
-    end
 end


### PR DESCRIPTION
This PR changes how recurring tasks are defined and how they're enqueued. They're no longer part of the `dispatchers` configuration or enqueued by the dispatchers. Instead, they have their own configuration file (`config/recurring.yml`, but it can be changed) and their own process, a new _scheduler_ that's just in charge of enqueuing jobs for recurring tasks. Besides, the configuration for each task has been extended, and now it allows optionally specifying a `queue` and `priority`, and it also supports providing just a "command" (any Ruby code) instead of requiring a job class and arguments. The command will be eval'ed within a new `SolidQueue::RecurringJob` provided as well. This is how the new configuration looks like: 

```yml
a_periodic_job:
  class: MyJob
  args: [ 42, { status: "custom_status" } ]
  schedule: every second
a_cleanup_task:
  command: "DeletedStuff.clear_all"
  queue: cleanup
  priority: 2
  schedule: every day at 9am
```
