### PR TITLE
add hook for job

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -66,3 +66,5 @@ module SolidQueue
     end
   end
 end
+
+ActiveSupport.run_load_hooks :solid_queue_job, SolidQueue::Job


### PR DESCRIPTION
For some reasons,  I really want this feature:
1. add callback after job finished;
2. add more scope for job model; 


If add this hook, I can override job model more easily.