### PR TITLE
Update Thor CLI options to respect ENV variables for default values

### DIFF
--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -5,13 +5,11 @@ require "thor"
 module SolidQueue
   class Cli < Thor
     class_option :config_file, type: :string, aliases: "-c",
-      default: Configuration::DEFAULT_CONFIG_FILE_PATH,
-      desc: "Path to config file",
+      desc: "Path to config file (default: #{Configuration::DEFAULT_CONFIG_FILE_PATH}).",
       banner: "SOLID_QUEUE_CONFIG"
 
     class_option :recurring_schedule_file, type: :string,
-      default: Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH,
-      desc: "Path to recurring schedule definition",
+      desc: "Path to recurring schedule definition (default: #{Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH}).",
       banner: "SOLID_QUEUE_RECURRING_SCHEDULE"
 
     class_option :skip_recurring, type: :boolean, default: false,


### PR DESCRIPTION
With the introduction of `bin/jobs` in #308, I noticed that it ignores the `SOLID_QUEUE_CONFIG` environment variable (and the recently introduced `SOLID_QUEUE_RECURRING_SCHEDULE`), while `rails solid_queue:start` still respects both of them.

This PR is my attempt to fix it.

Please let me know if it is worth adding tests for the `SolidQueue::Cli`.

Also, I hope that the direction is correct, although the logic duplicates `default_options` from `SolidQueue::Configuration`.
