### PR TITLE
fix:  prevent duplicate configuration lines in production.rb

### DIFF
--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -14,12 +14,19 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
   def configure_active_job_adapter
     production_rb = Pathname(destination_root).join("config/environments/production.rb")
 
-    # Replace the active_job queue_adapter line
-    gsub_file(production_rb, /(# )?config\.active_job\.queue_adapter\s+=.*/, "config.active_job.queue_adapter = :solid_queue")
+    # Replace or set `config.active_job.queue_adapter`
+    gsub_file Pathname(destination_root).join("config/environments/production.rb"),
+    /config\.active_job\.queue_adapter\s+=.*/,
+    "config.active_job.queue_adapter = :solid_queue"
 
-    # Add the solid_queue connects_to line if it doesn't exist
-    unless File.foreach(production_rb).any? { |line| line.include?("config.solid_queue.connects_to = { database: { writing: :queue } }") }
-      inject_into_file(production_rb, "\n  config.solid_queue.connects_to = { database: { writing: :queue } }", after: "config.active_job.queue_adapter = :solid_queue\n")
-    end
+    # Inject `config.solid_queue.connects_to` if not already present
+    gsub_file Pathname(destination_root).join("config/environments/production.rb"),
+    /^\s*config\.solid_queue\.connects_to\s+=\s+\{.*\}\n/,
+    '',
+    verbose: false # If found, do nothing
+
+    inject_into_file Pathname(destination_root).join("config/environments/production.rb"),
+    "\n  config.solid_queue.connects_to = { database: { writing: :queue } }",
+    after: /config\.active_job\.queue_adapter\s+=.*/
   end
 end

--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -22,7 +22,7 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
     # Inject `config.solid_queue.connects_to` if not already present
     gsub_file Pathname(destination_root).join("config/environments/production.rb"),
     /^\s*config\.solid_queue\.connects_to\s+=\s+\{.*\}\n/,
-    '',
+    "",
     verbose: false # If found, do nothing
 
     inject_into_file Pathname(destination_root).join("config/environments/production.rb"),

--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -12,9 +12,14 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
   end
 
   def configure_active_job_adapter
-    gsub_file Pathname(destination_root).join("config/environments/production.rb"),
-      /(# )?config\.active_job\.queue_adapter\s+=.*/,
-      "config.active_job.queue_adapter = :solid_queue\n" +
-      "  config.solid_queue.connects_to = { database: { writing: :queue } }\n"
+    production_rb = Pathname(destination_root).join("config/environments/production.rb")
+
+    # Replace the active_job queue_adapter line
+    gsub_file(production_rb, /(# )?config\.active_job\.queue_adapter\s+=.*/, "config.active_job.queue_adapter = :solid_queue")
+
+    # Add the solid_queue connects_to line if it doesn't exist
+    unless File.foreach(production_rb).any? { |line| line.include?("config.solid_queue.connects_to = { database: { writing: :queue } }") }
+      inject_into_file(production_rb, "\n  config.solid_queue.connects_to = { database: { writing: :queue } }", after: "config.active_job.queue_adapter = :solid_queue\n")
+    end
   end
 end


### PR DESCRIPTION
The generator was adding duplicate lines to production.rb each time it is run 

```
  config.active_job.queue_adapter = :solid_queue
  config.solid_queue.connects_to = { database: { writing: :queue } }
  
  config.solid_queue.connects_to = { database: { writing: :queue } }
```

This PR refactors the generator to:
1. Check if the line already exists before adding it.
2. With this, generator logs to the terminal whether a new line was inserted along with gsub
