### PR TITLE
Clear previous changes before locking process for heartbeat

### DIFF
--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -20,7 +20,11 @@ class SolidQueue::Process < SolidQueue::Record
   end
 
   def heartbeat
-    touch(:last_heartbeat_at)
+    # Clear any previous changes before locking, for example, in case a previous heartbeat
+    # failed because of a DB issue (with SQLite depending on configuration, a BusyException
+    # is not rare) and we still have the unpersisted value
+    restore_attributes
+    with_lock { touch(:last_heartbeat_at) }
   end
 
   def deregister(pruned: false)

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -53,7 +53,7 @@ module SolidQueue::Processes
       end
 
       def heartbeat
-        process.with_lock { process.heartbeat }
+        process.heartbeat
       rescue ActiveRecord::RecordNotFound
         self.process = nil
         wake_up

--- a/test/models/solid_queue/process_test.rb
+++ b/test/models/solid_queue/process_test.rb
@@ -69,4 +69,16 @@ class SolidQueue::ProcessTest < ActiveSupport::TestCase
       worker.stop
     end
   end
+
+  test "clear unregistered changes before locking for heartbeat" do
+    process = SolidQueue::Process.register(kind: "Supervisor", pid: 43, name: "supervisor-43")
+
+    # Pretend a heartbeat failed to persist
+    failed_heartbeat_at = 10.minutes.ago
+    process.last_heartbeat_at = failed_heartbeat_at
+
+    assert_changes -> { process.last_heartbeat_at } do
+      process.heartbeat
+    end
+  end
 end


### PR DESCRIPTION
For example, in case of a previous heartbeat failed because of a DB issue (with SQLite depending on configuration, a `BusyException` is not rare) and we still have the unpersisted value in `last_heartbeat_at`, which means that `with_lock` will result in:
```
RuntimeError: Locking a record with unpersisted changes is not supported
```

Fixes #350