### PR TITLE
Fixes #262: Automatic worker process recycling

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -65,8 +65,6 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     else
       failed_with(result.error)
     end
-  ensure
-    job.unblock_next_blocked_job
   end
 
   def release

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -40,6 +40,7 @@ module SolidQueue
   mattr_accessor :preserve_finished_jobs, default: true
   mattr_accessor :clear_finished_jobs_after, default: 1.day
   mattr_accessor :default_concurrency_control_period, default: 3.minutes
+  mattr_accessor :calc_memory_usage, default: nil
 
   delegate :on_start, :on_stop, to: Supervisor
 

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -61,6 +61,20 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     end
   end
 
+  def recycle_worker(event)
+    process = event.payload[:process]
+
+    attributes = {
+      memory_used: event.payload[:memory_used],
+      pid: process.pid,
+      hostname: process.hostname,
+      process_id: process.process_id,
+      name: process.name
+    }
+
+    warn formatted_event(event, action: "#{process.kind} OOM", **attributes)
+  end
+
   def start_process(event)
     process = event.payload[:process]
 

--- a/lib/solid_queue/processes/recyclable.rb
+++ b/lib/solid_queue/processes/recyclable.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module SolidQueue::Processes
+  module Recyclable
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :max_memory, :calc_memory_usage
+    end
+
+    def recyclable_setup(**options)
+      return unless configured?(options)
+
+      set_max_memory(options[:recycle_on_oom])
+      set_calc_memory_usage if max_memory
+      SolidQueue.logger.error { "Recycle on OOM is disabled for worker #{pid}" } unless oom_configured?
+    end
+
+    def recycle(execution = nil)
+      return false if !oom_configured? || stopped?
+
+      memory_used = calc_memory_usage.call(pid)
+      return false unless memory_exceeded?(memory_used)
+
+      SolidQueue.instrument(:recycle_worker, process: self, memory_used: memory_used, class_name: execution&.job&.class_name) do
+        pool.shutdown
+        stop
+      end
+
+      true
+    end
+
+    def oom?
+      oom_configured? && calc_memory_usage.call(pid) > max_memory
+    end
+
+    private
+
+      def configured?(options)
+        options.key?(:recycle_on_oom)
+      end
+
+      def oom_configured?
+        @oom_configured ||= max_memory.present? && calc_memory_usage.present?
+      end
+
+      def memory_exceeded?(memory_used)
+        memory_used > max_memory
+      end
+
+      def set_max_memory(max_memory)
+        if max_memory > 0
+          @max_memory = max_memory
+        else
+          SolidQueue.logger.error { "Invalid value for recycle_on_oom: #{max_memory}." }
+        end
+      end
+
+      def set_calc_memory_usage
+        if SolidQueue.calc_memory_usage.respond_to?(:call)
+          @calc_memory_usage = SolidQueue.calc_memory_usage
+        else
+          SolidQueue.logger.error { "SolidQueue.calc_memory_usage provider not configured." }
+        end
+      end
+  end
+end

--- a/test/dummy/app/jobs/recycle_job.rb
+++ b/test/dummy/app/jobs/recycle_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RecycleJob < ApplicationJob
+  def perform(nap = nil)
+    sleep(nap) unless nap.nil?
+  end
+end

--- a/test/dummy/app/jobs/recycle_with_concurrency_job.rb
+++ b/test/dummy/app/jobs/recycle_with_concurrency_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RecycleWithConcurrencyJob < ApplicationJob
+  limits_concurrency key: ->(nap = nil) { }
+
+  def perform(nap = nil)
+    sleep(nap) unless nap.nil?
+  end
+end

--- a/test/integration/recycle_worker_test.rb
+++ b/test/integration/recycle_worker_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "thread"
+
+class RecycleWorkerTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  attr_accessor :pid
+
+  def setup
+    @pid = nil
+  end
+
+  teardown do
+    terminate_process(@pid) if process_exists?(@pid)
+  end
+
+  test "recycle_on_oom set via worker config" do
+    @pid, _count = start_solid_queue(default_worker, calc_memory_usage_oom)
+
+    SolidQueue::Process.where(kind: "Worker").each do |worker|
+      assert worker.metadata.has_key?("recycle_on_oom"), "Worker not configured for recycle_on_oom #{worker.id} #{worker.metadata}\n"
+    end
+  end
+
+  test "recycle_on_oom via worker config per worker" do
+    workers = [
+      { queues: "with", polling_interval: 0.1, processes: 3, threads: 2, recycle_on_oom: 1 },
+      { queues: "without", polling_interval: 0.1, processes: 3, threads: 2 }
+    ]
+
+    @pid, _count = start_solid_queue(workers, calc_memory_usage_oom)
+
+    process_with, process_without = SolidQueue::Process.where(kind: "Worker").partition { _1.metadata["queues"] == "with" }
+
+    assert process_with.all? { _1.metadata.has_key?("recycle_on_oom") }, "Worker unexpectedly configured without recycle_on_oom"
+    assert process_without.none? { _1.metadata.has_key?("recycle_on_oom") }, "Worker unexpectedly configured with recycle_on_oom"
+  end
+
+  test "recycle_on_oom is an optional config parameter" do
+    worker_without_recycle = default_worker.tap { _1.delete(:recycle_on_oom) }
+    @pid, _count = start_solid_queue(worker_without_recycle, calc_memory_usage_oom)
+
+    SolidQueue::Process.where(kind: "Worker").each do |worker|
+      assert_not worker.metadata.has_key?("recycle_on_oom"), "Worker configured for recycle_on_oom #{worker.id} #{worker.metadata}\n"
+    end
+  end
+
+  test "recycle_on_oom is off globally without setting calc_memory_usage (default)" do
+    @pid, _count = start_solid_queue(default_worker, calc_memory_usage_off)
+
+    SolidQueue::Process.where(kind: "Worker").each do |worker|
+      assert_not worker.metadata.has_key?("recycle_on_oom"), "Worker configured for recycle_on_oom #{worker.id} #{worker.metadata}\n"
+    end
+  end
+
+  test "Workers don't recycle unless configured" do
+    @pid, count = start_solid_queue(default_worker, calc_memory_usage_off) # this turns recycle OFF
+
+    _before_id, before_pid = worker_process
+    assert_not before_pid.nil?, "Before PID nil"
+
+    jobs = 0.upto(5).map { RecycleJob.new }
+    ActiveJob.perform_all_later(jobs)
+
+    wait_for_jobs_to_finish_for(6.seconds)
+    assert_no_unfinished_jobs
+    wait_for_registered_processes(count, timeout: 1.second)
+
+    _before_id, after_pid = worker_process
+    assert_not after_pid.nil?, "After PID nil"
+
+    assert before_pid == after_pid, "Worker unexpectedly recycled"
+  end
+
+  test "Worker recycles on OOM condition" do
+    @pid, count = start_solid_queue(default_worker, calc_memory_usage_oom)
+
+    before_id, before_pid = worker_process
+    assert_not before_pid.nil?, "Before PID nil"
+
+    jobs = 0.upto(5).map { RecycleJob.new }
+    ActiveJob.perform_all_later(jobs)
+
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert_no_unfinished_jobs
+    wait_for_registered_processes(count, timeout: 1.second)
+
+    after_id, after_pid = worker_process
+
+    assert_not after_pid.nil?, "After PID nil"
+    assert before_pid != after_pid, "Worker didn't recycled"
+  end
+
+  test "Worker don't recycle without OOM condition" do
+    @pid, count = start_solid_queue(default_worker, calc_memory_usage_not_oom)
+
+    before_id, before_pid = worker_process
+    assert_not before_pid.nil?, "Before PID nil"
+
+    jobs = 0.upto(5).map { RecycleJob.new }
+    ActiveJob.perform_all_later(jobs)
+
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert_no_unfinished_jobs
+    wait_for_registered_processes(count, timeout: 1.second)
+
+    after_id, after_pid = worker_process
+
+    assert_not after_pid.nil?, "After PID nil"
+    assert before_pid == after_pid, "Worker unexpectedly recycled PID"
+    assert before_id == after_id, "Worker unexpectedly created new Process row"
+  end
+
+  test "Jobs on threads finish even when worker recycles on OOM" do
+    workers = { queues: %w[fast slow], polling_interval: 0.1, processes: 1, threads: 2, recycle_on_oom: 1 }
+    @pid, count = start_solid_queue(workers, calc_memory_usage_oom)
+
+    before_id, before_pid = worker_process
+    assert_not before_pid.nil?, "Before PID nil"
+
+    RecycleJob.set(queue: "slow").perform_later(2)
+    RecycleJob.set(queue: "fast").perform_later(0)
+    RecycleJob.set(queue: "slow").perform_later(2)
+    RecycleJob.set(queue: "fast").perform_later(0)
+
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert_no_unfinished_jobs
+    wait_for_registered_processes(count, timeout: 1.second)
+
+    after_id, after_pid = worker_process
+
+    assert_not after_pid.nil?, "After PID nil"
+    assert before_pid != after_pid, "Worker didn't create new PID"
+    assert before_id != after_id, "Worker did not created new Process row"
+  end
+
+  test "Jobs that hold locks are released on OOM recycle " do
+    @pid, count = start_solid_queue(default_worker, calc_memory_usage_oom)
+
+    before_id, before_pid = worker_process
+    assert_not before_pid.nil?, "Before PID nil"
+
+    jobs = 0.upto(9).map { RecycleJob.new }
+    ActiveJob.perform_all_later(jobs)
+
+    wait_for_jobs_to_finish_for(15.seconds)
+    assert_no_unfinished_jobs
+    wait_for_registered_processes(count, timeout: 1.second)
+
+    after_id, after_pid = worker_process
+
+    assert_not after_pid.nil?, "After PID nil"
+    assert before_pid != after_pid, "Worker didn't change PID"
+  end
+
+  private
+    def start_solid_queue(workers, calc_memory_usage)
+      w = workers.is_a?(Array) ? workers : [ workers ]
+
+      pid = fork do
+        SolidQueue.calc_memory_usage = calc_memory_usage
+        SolidQueue.shutdown_timeout = 1.second
+
+        SolidQueue::Supervisor.start(workers: w, dispatchers: default_dispatcher, skip_recurring: true)
+      end
+
+      expected_process_count = w.sum { _1.fetch(:processes, 1) } + 2 # supervisor + dispatcher
+      wait_for_registered_processes(expected_process_count, timeout: 0.5.second) # 3 workers working the default queue + dispatcher + supervisor
+
+      [ pid, expected_process_count ]
+    end
+
+    def worker_process
+      SolidQueue::Process.find_by(kind: "Worker")&.slice(:id, :pid)&.values
+    end
+
+    def calc_memory_usage_oom
+      ->(_pid) { 2 }
+    end
+
+    def calc_memory_usage_not_oom
+      ->(_pid) { 0 }
+    end
+
+    def calc_memory_usage_off
+      nil
+    end
+
+    def default_dispatcher
+      [ { polling_interval: 0.1, batch_size: 100, concurrency_maintenance_interval: 600 } ]
+    end
+
+    def default_worker
+      { queues: "default", polling_interval: 0.1, processes: 3, threads: 1, recycle_on_oom: 1 }
+    end
+end


### PR DESCRIPTION
This PR adds two new configuration parameters:
* recycle_on_oom to the Worker (via queue.yml)
* calc_memory_usage as a global parameter (via application.rb, environment/*.rb, or an initializer)

There are no specific unit requirements placed on either of these new parameters. What's important is: They use the same order of magnitude and they are comparable.

For example, if the calc_memory_usage proc returns 300Mb as 300 (as in Megabytes) then the recycle_on_oom set on the work should be 300 too.

Any worker without recycle_on_oom is not impacted in anyway. If the calc_memory_usage is nil (default), then this oom checking it off for workers under the control of this Supervisor.

The check for OOM is made after the Job has run to completion and before the SolidQueue worker does any additional processing.

The single biggest change to SolidQueue, that probably requires the most review is moving the job.unblock_next_blocked_job out of ClaimedExecution and up one level into Pool.  The rational for this change is that the ensure block on the Job execution is not guarrenteed to run if the system / thread is forcibly shutdown while the job is inflight.  However, the Thread.ensure *does* seem to get called reliably on forced shutdowns.

Give my almost assuredly incomplete understanding of the concurrency implementation despite Rosa working very hard to help me to grok it, there is some risk here that this change is wrong.

My logic for this change is as follows:
* A job that complete successfully would have release its lock -- no change
* A job that completes by way of an unhandled exception would have released its lock -- no change
* A job that was killed inflight because of a worker recycle_on_oom (or an ugly restart out of the users control -- again, looking at you Heroku) needs to release its lock -- there is no guarantee that its going to be the job that starts on the worker restart.  If release its lock in this use-case, then it doesn't, then that worker could find itself waiting on the dispatcher (I think) to expire Semaphores before it is able to take on new work.

Small fix