### PR TITLE
Fix: Replace static table names in schema definition

### DIFF
--- a/lib/generators/solid_queue/install/templates/db/queue_schema.rb
+++ b/lib/generators/solid_queue/install/templates/db/queue_schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema[7.1].define(version: 1) do
-  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+  create_table SolidQueue::BlockedExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false

--- a/lib/generators/solid_queue/install/templates/db/queue_schema.rb
+++ b/lib/generators/solid_queue/install/templates/db/queue_schema.rb
@@ -1,32 +1,32 @@
 ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
-  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+  create_table SolidQueue::BlockedExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_#{SolidQueue::BlockedExecution.table_name}_for_release"
+    t.index [ "expires_at", "concurrency_key" ], name: "index_#{SolidQueue::BlockedExecution.table_name}_for_maintenance"
+    t.index [ "job_id" ], name: "index_#{SolidQueue::BlockedExecution.table_name}_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+  create_table SolidQueue::ClaimedExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index [ "job_id" ], name: "index_#{SolidQueue::ClaimedExecution.table_name}_on_job_id", unique: true
+    t.index [ "process_id", "job_id" ], name: "index_#{SolidQueue::ClaimedExecution.table_name}_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", force: :cascade do |t|
+  create_table SolidQueue::FailedExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.index [ "job_id" ], name: "index_#{SolidQueue::FailedExecution.table_name}_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", force: :cascade do |t|
+  create_table SolidQueue::Job.table_name, force: :cascade do |t|
     t.string "queue_name", null: false
     t.string "class_name", null: false
     t.text "arguments"
@@ -37,20 +37,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index [ "active_job_id" ], name: "index_#{SolidQueue::Job.table_name}_on_active_job_id"
+    t.index [ "class_name" ], name: "index_#{SolidQueue::Job.table_name}_on_class_name"
+    t.index [ "finished_at" ], name: "index_#{SolidQueue::Job.table_name}_on_finished_at"
+    t.index [ "queue_name", "finished_at" ], name: "index_#{SolidQueue::Job.table_name}_for_filtering"
+    t.index [ "scheduled_at", "finished_at" ], name: "index_#{SolidQueue::Job.table_name}_for_alerting"
   end
 
-  create_table "solid_queue_pauses", force: :cascade do |t|
+  create_table SolidQueue::Pause.table_name, force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.index [ "queue_name" ], name: "index_#{SolidQueue::Pause.table_name}_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", force: :cascade do |t|
+  create_table SolidQueue::Process.table_name, force: :cascade do |t|
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
     t.bigint "supervisor_id"
@@ -59,31 +59,31 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
     t.text "metadata"
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    t.index [ "last_heartbeat_at" ], name: "index_#{SolidQueue::Process.table_name}_on_last_heartbeat_at"
+    t.index [ "name", "supervisor_id" ], name: "index_#{SolidQueue::Process.table_name}_on_name_and_supervisor_id", unique: true
+    t.index [ "supervisor_id" ], name: "index_#{SolidQueue::Process.table_name}_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", force: :cascade do |t|
+  create_table SolidQueue::ReadyExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index [ "job_id" ], name: "index_#{SolidQueue::ReadyExecution.table_name}_on_job_id", unique: true
     t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
     t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+  create_table SolidQueue::RecurringExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "task_key", null: false
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index [ "job_id" ], name: "index_#{SolidQueue::RecurringExecution.table_name}_on_job_id", unique: true
+    t.index [ "task_key", "run_at" ], name: "index_#{SolidQueue::RecurringExecution.table_name}_on_task_key_and_run_at", unique: true
   end
 
-  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+  create_table SolidQueue::RecurringTask.table_name, force: :cascade do |t|
     t.string "key", null: false
     t.string "schedule", null: false
     t.string "command", limit: 2048
@@ -95,35 +95,35 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index [ "key" ], name: "index_#{SolidQueue::RecurringTask.table_name}_on_key", unique: true
+    t.index [ "static" ], name: "index_#{SolidQueue::RecurringTask.table_name}_on_static"
   end
 
-  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+  create_table SolidQueue::ScheduledExecution.table_name, force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index [ "job_id" ], name: "index_#{SolidQueue::ScheduledExecution.table_name}_on_job_id", unique: true
     t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", force: :cascade do |t|
+  create_table SolidQueue::Semaphore.table_name, force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 1, null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.index [ "expires_at" ], name: "index_#{SolidQueue::Semaphore.table_name}_on_expires_at"
+    t.index [ "key", "value" ], name: "index_#{SolidQueue::Semaphore.table_name}_on_key_and_value"
+    t.index [ "key" ], name: "index_#{SolidQueue::Semaphore.table_name}_on_key", unique: true
   end
 
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::BlockedExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::ClaimedExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::FailedExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::ReadyExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::RecurringExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
+  add_foreign_key SolidQueue::ScheduledExecution.table_name, SolidQueue::Job.table_name, column: "job_id", on_delete: :cascade
 end


### PR DESCRIPTION
The schema definition in `db/queue_schema.rb` uses static plural table names. If rails runs with `config.active_record.pluralize_table_names = false`, this leads to an error as soon as solid_queue tries to access the DB.

The static strings for the table names in the schema definition are replaced by the `table_name` method of the corresponding model class. This ensures that the tables are named correctly in plural or singular respectively.