### PR TITLE
Add missing example for `config.solid_queue.connects_to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ There are several settings that control how Solid Queue works that you can set a
   **This is not used for errors raised within a job execution**. Errors happening in jobs are handled by Active Job's `retry_on` or `discard_on`, and ultimately will result in [failed jobs](#failed-jobs-and-retries). This is for errors happening within Solid Queue itself.
 
 - `connects_to`: a custom database configuration that will be used in the abstract `SolidQueue::Record` Active Record model. This is required to use a different database than the main app. For example:
+
+  ```ruby
+  # Use a separate DB for Solid Queue
+  config.solid_queue.connects_to = { database: { writing: :solid_queue_primary, reading: :solid_queue_replica } }
+  ```
+
+  Make sure that the `solid_queue_primary ` and `solid_queue_replica` names match what's configured in `database.yml`!
+
 - `use_skip_locked`: whether to use `FOR UPDATE SKIP LOCKED` when performing locking reads. This will be automatically detected in the future, and for now, you'd only need to set this to `false` if your database doesn't support it. For MySQL, that'd be versions < 8, and for PostgreSQL, versions < 9.5. If you use SQLite, this has no effect, as writes are sequential.
 - `process_heartbeat_interval`: the heartbeat interval that all processes will follow—defaults to 60 seconds.
 - `process_alive_threshold`: how long to wait until a process is considered dead after its last heartbeat—defaults to 5 minutes.


### PR DESCRIPTION
The `connects_to` parameter description in the current README has an incomplete sentence that ends with "For example:".

This PR adds such an example to the README.