### PR TITLE
Fix memoization for `#recurring_tasks_config`

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -111,7 +111,7 @@ module SolidQueue
       end
 
       def recurring_tasks_config
-        @recurring_tasks ||= config_from options[:recurring_schedule_file]
+        @recurring_tasks_config ||= config_from options[:recurring_schedule_file]
       end
 
 


### PR DESCRIPTION
First, thanks for all of your work on this gem! I love watching the progress.

I was reviewing the recurrence implementation and noticed the memoized instance variable name was shared for both `#recurring_tasks` and `#recurring_tasks_config`. This appears to have been introduced in 0aa1644e38dd8c8cfcaf6d0ce3cd9e22ebd1a90b.

This isn't causing any bugs for me currently, but I figured this PR would help prevent any potential issues in the future.