### PR TITLE
Remove redundant `run` methods in `SolidQueue::Processes`

### DIFF
--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -41,10 +41,6 @@ module SolidQueue::Processes
         end
       end
 
-      def run
-        raise NotImplementedError
-      end
-
       def shutting_down?
         stopped? || (running_as_fork? && supervisor_went_away?) || finished? || !registered?
       end


### PR DESCRIPTION
This commit removes one of the redundant `run` methods in `SolidQueue::Processes`

Here are the warning messages appeared at Rails Nightly CI: https://buildkite.com/rails/rails-nightly/builds/1091#019244bc-9d36-476d-8924-5e2bea4cb728/1173-1176
```
/usr/local/lib/ruby/gems/3.4.0+0/gems/solid_queue-1.0.0/lib/solid_queue/processes/runnable.rb:52: warning: method redefined; discarding old run
/usr/local/lib/ruby/gems/3.4.0+0/gems/solid_queue-1.0.0/lib/solid_queue/processes/runnable.rb:44: warning: previous definition of run was here
```