### PR TITLE
Address Ruby warnings

### DIFF
--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -4,7 +4,7 @@ module SolidQueue
   class Record < ActiveRecord::Base
     self.abstract_class = true
 
-    connects_to **SolidQueue.connects_to if SolidQueue.connects_to
+    connects_to(**SolidQueue.connects_to) if SolidQueue.connects_to
 
     def self.non_blocking_lock
       if SolidQueue.use_skip_locked

--- a/lib/solid_queue/supervisor/pidfile.rb
+++ b/lib/solid_queue/supervisor/pidfile.rb
@@ -29,7 +29,7 @@ module SolidQueue
         else
           FileUtils.mkdir_p File.dirname(path)
         end
-      rescue Errno::ESRCH => e
+      rescue Errno::ESRCH
         # Process is dead, ignore, just delete the file
         delete
       rescue Errno::EPERM


### PR DESCRIPTION
This commit addresses the following warnings appeared at Rails Nightly CI https://buildkite.com/rails/rails-nightly/builds/1095#019249e3-405c-4c52-ad8d-497f46a5c6a5/1244-1249

```ruby
/usr/local/lib/ruby/gems/3.4.0+0/gems/solid_queue-1.0.0/lib/solid_queue/supervisor/pidfile.rb:32: warning: assigned but unused variable - e
/usr/local/lib/ruby/gems/3.4.0+0/gems/solid_queue-1.0.0/app/models/solid_queue/record.rb:7: warning: ambiguous `**` has been interpreted as an argument prefix
```