### PR TITLE
Use Current Migration Version

### DIFF
--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -6,7 +6,7 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
   def copy_files
     template "config/queue.yml"
     template "config/recurring.yml"
-    template "db/queue_schema.rb"
+    template "db/queue_schema.rb.tt"
     template "bin/jobs"
     chmod "bin/jobs", 0755 & ~File.umask, verbose: false
   end

--- a/lib/generators/solid_queue/install/templates/db/queue_schema.rb.tt
+++ b/lib/generators/solid_queue/install/templates/db/queue_schema.rb.tt
@@ -1,4 +1,4 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+ActiveRecord::Schema[<%= ActiveRecord::Migration.current_version %>].define(version: 1) do
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false


### PR DESCRIPTION
Hola 👋 

I've noticed that when installing Solid Queue in Rails projects (version 7.1 and above), the generator continues to use the older version for the queue schema, 7.1. I'm curious if this is intentional and whether aligning it with the current project version might be more appropriate. As of now, Rails versions 7.1, 7.2, and 8.0 don't seem to have any compatibility issues, so this hasn't caused problems.

https://github.com/rails/rails/blob/4f68f3e1e6c2eaad8256100dad51d308e7e67046/activerecord/lib/active_record/migration/compatibility.rb#L32-L38

However, for future Rails releases, it might be beneficial for the generator to track and use the version in use.

Gracias 🙇 


