### PR TITLE
Add compatibility with strict_loading_by_default

### DIFF
--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -3,6 +3,7 @@
 module SolidQueue
   class Record < ActiveRecord::Base
     self.abstract_class = true
+    self.strict_loading_by_default = false
 
     include DistinctValues
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -28,5 +28,7 @@ module Dummy
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_job.queue_adapter = :solid_queue
+
+    config.active_record.strict_loading_by_default = true
   end
 end


### PR DESCRIPTION
Fixes #122

Allows the app to run in `strict_loading_by_default` mode by explicitly turning off strict loading on all Solid Queue models.

Also enables `strict_loading_by_default` on the dummy app to prevent strict loading issues from being introduced.

##### Alternative / strict_loading enabled
I tried to support strict_loading instead of turning it off, but after spending time on it, I don't think it's worth it. It is a little bit faster, but bring a bunch of complexity. 
I opened a draft PR on my fork to demonstrate what it would look like: https://github.com/JoeDupuis/solid_queue/pull/1
Even if we decide to go down the road of enabling strict_loading in Solid Queue, we should merge this PR first to unblock strict_loading apps while working on the fix.
