### PR TITLE
Fix queue order when combining multiple prefixes or prefixes and names 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,5 +53,3 @@ jobs:
           bin/rails db:setup
       - name: Run tests
         run: bin/rails test
-      - name: Run tests with separate connection
-        run: SEPARATE_CONNECTION=1 bin/rails test

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /tmp/
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-*
-/test/dummy/log/*.log
+/test/dummy/log/*.log*
 /test/dummy/tmp/
 
 # Folder for JetBrains IDEs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,4 @@ AllCops:
   TargetRubyVersion: 3.0
   Exclude:
     - "test/dummy/db/schema.rb"
+    - "test/dummy/db/queue_schema.rb"

--- a/bin/setup
+++ b/bin/setup
@@ -2,11 +2,19 @@
 set -eu
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker-compose up -d --remove-orphans
-docker-compose ps
+if docker compose version &> /dev/null; then
+  DOCKER_COMPOSE_CMD="docker compose"
+else
+  DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+$DOCKER_COMPOSE_CMD up -d --remove-orphans
+$DOCKER_COMPOSE_CMD ps
 
 bundle
 
 echo "Creating databases..."
 
-rails db:reset
+rails db:reset TARGET_DB=sqlite
+rails db:reset TARGET_DB=mysql
+rails db:reset TARGET_DB=postgres

--- a/test/dummy/bin/jobs
+++ b/test/dummy/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -28,9 +28,5 @@ module Dummy
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_job.queue_adapter = :solid_queue
-
-    if ENV["SEPARATE_CONNECTION"] && ENV["TARGET_DB"] != "sqlite"
-      config.solid_queue.connects_to = { database: { writing: :primary, reading: :replica } }
-    end
   end
 end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -35,19 +35,19 @@ default: &default
 development:
   primary:
     <<: *default
-    database: <%= database_name_from("solid_queue_development") %>
-  replica:
+    database: <%= database_name_from("development") %>
+  queue:
     <<: *default
-    database: <%= database_name_from("solid_queue_development") %>
-    replica: true
+    database: <%= database_name_from("development_queue") %>
+    migrations_paths: db/queue_migrate
 
 test:
   primary:
     <<: *default
     pool: 20
-    database: <%= database_name_from("solid_queue_test") %>
-  replica:
+    database: <%= database_name_from("test") %>
+  queue:
     <<: *default
     pool: 20
-    database: <%= database_name_from("solid_queue_test") %>
-    replica: true
+    database: <%= database_name_from("test_queue") %>
+    migrations_paths: db/queue_migrate

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -51,6 +51,10 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
+  # Replace the default in-process and non-durable queuing backend for Active Job.
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -44,8 +44,10 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # Replace the default in-process and non-durable queuing backend for Active Job.
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # config.active_job.queue_name_prefix = "dummy_production"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -47,6 +47,10 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
+  # Replace the default in-process and non-durable queuing backend for Active Job.
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/test/dummy/db/queue_schema.rb
+++ b/test/dummy/db/queue_schema.rb
@@ -1,0 +1,141 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+end

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -249,21 +249,19 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     end
   end
 
-  if ENV["SEPARATE_CONNECTION"] && ENV["TARGET_DB"] != "sqlite"
-    test "uses a different connection and transaction than the one in use when connects_to is specified" do
-      assert_difference -> { SolidQueue::Job.count } do
-        assert_no_difference -> { JobResult.count } do
-          JobResult.transaction do
-            JobResult.create!(queue_name: "default", value: "this will be rolled back")
-            StoreResultJob.perform_later("enqueued inside a rolled back transaction")
-            raise ActiveRecord::Rollback
-          end
+  test "enqueue successfully inside a rolled-back transaction in the app DB" do
+    assert_difference -> { SolidQueue::Job.count } do
+      assert_no_difference -> { JobResult.count } do
+        JobResult.transaction do
+          JobResult.create!(queue_name: "default", value: "this will be rolled back")
+          StoreResultJob.perform_later("enqueued inside a rolled back transaction")
+          raise ActiveRecord::Rollback
         end
       end
-
-      job = SolidQueue::Job.last
-      assert_equal "enqueued inside a rolled back transaction", job.arguments.dig("arguments", 0)
     end
+
+    job = SolidQueue::Job.last
+    assert_equal "enqueued inside a rolled back transaction", job.arguments.dig("arguments", 0)
   end
 
   private

--- a/test/models/solid_queue/ready_execution_test.rb
+++ b/test/models/solid_queue/ready_execution_test.rb
@@ -49,42 +49,11 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     end
   end
 
-  test "queue order and then priority is respected when using a list of queues" do
-    AddToBufferJob.perform_later("hey")
-    job = SolidQueue::Job.last
-    assert_equal "background", job.queue_name
-
-    assert_claimed_jobs(3) do
-      SolidQueue::ReadyExecution.claim(%w[ background backend ], 3, 42)
-    end
-
-    assert job.reload.claimed?
-    @jobs.first(2).each do |job|
-      assert_not job.reload.ready?
-      assert job.claimed?
-    end
-  end
-
   test "claim jobs using a wildcard" do
     AddToBufferJob.perform_later("hey")
 
     assert_claimed_jobs(6) do
       SolidQueue::ReadyExecution.claim("*", SolidQueue::Job.count + 1, 42)
-    end
-  end
-
-  test "priority order is used when claiming jobs using a wildcard" do
-    AddToBufferJob.set(priority: 1).perform_later("hey")
-    job = SolidQueue::Job.last
-
-    assert_claimed_jobs(3) do
-      SolidQueue::ReadyExecution.claim("*", 3, 42)
-    end
-
-    assert job.reload.claimed?
-    @jobs.first(2).each do |job|
-      assert_not job.reload.ready?
-      assert job.claimed?
     end
   end
 
@@ -111,7 +80,7 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     assert @jobs.none?(&:claimed?)
   end
 
-  test "claim jobs using both exact names and a prefixes" do
+  test "claim jobs using both exact names and a prefix" do
     AddToBufferJob.perform_later("hey")
 
     assert_claimed_jobs(6) do
@@ -125,6 +94,78 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     assert_claimed_jobs(0) do
       SolidQueue::ReadyExecution.claim(%w[ none* ], SolidQueue::Job.count + 1, 42)
     end
+  end
+
+  test "priority order is used when claiming jobs using a wildcard" do
+    AddToBufferJob.set(priority: 1).perform_later("hey")
+    job = SolidQueue::Job.last
+
+    assert_claimed_jobs(3) do
+      SolidQueue::ReadyExecution.claim("*", 3, 42)
+    end
+
+    assert job.reload.claimed?
+    @jobs.first(2).each do |job|
+      assert_not job.reload.ready?
+      assert job.claimed?
+    end
+  end
+
+  test "queue order and then priority is respected when using a list of queues" do
+    AddToBufferJob.perform_later("hey")
+    job = SolidQueue::Job.last
+    assert_equal "background", job.queue_name
+
+    assert_claimed_jobs(3) do
+      SolidQueue::ReadyExecution.claim(%w[ background backend ], 3, 42)
+    end
+
+    assert job.reload.claimed?
+    @jobs.first(2).each do |job|
+      assert_not job.reload.ready?
+      assert job.claimed?
+    end
+  end
+
+  test "queue order is respected when using prefixes" do
+    %w[ queue_b1 queue_b2 queue_a2 queue_a1 queue_b1 queue_a2 queue_b2 queue_a1 ].each do |queue_name|
+      AddToBufferJob.set(queue: queue_name).perform_later(1)
+    end
+
+    # Claim 8 jobs
+    claimed_jobs = []
+    4.times do
+      assert_claimed_jobs(2) do
+        SolidQueue::ReadyExecution.claim(%w[ queue_b* queue_a* ], 2, 42)
+      end
+
+      claimed_jobs += SolidQueue::ClaimedExecution.order(:id).last(2).map(&:job)
+    end
+
+    # Check claim order
+    assert_equal %w[ queue_b1 queue_b1 queue_b2 queue_b2 queue_a1 queue_a1 queue_a2 queue_a2 ],
+      claimed_jobs.map(&:queue_name)
+  end
+
+
+  test "queue order is respected when mixing exact names with prefixes" do
+    %w[ queue_b1 queue_b2 queue_a2 queue_c2 queue_a1 queue_c1 queue_b1 queue_a2 queue_b2 queue_a1 ].each do |queue_name|
+      AddToBufferJob.set(queue: queue_name).perform_later(1)
+    end
+
+    # Claim 10 jobs
+    claimed_jobs = []
+    5.times do
+      assert_claimed_jobs(2) do
+        SolidQueue::ReadyExecution.claim(%w[ queue_a2 queue_c1 queue_b* queue_c2 queue_a* ], 2, 42)
+      end
+
+      claimed_jobs += SolidQueue::ClaimedExecution.order(:id).last(2).map(&:job)
+    end
+
+    # Check claim order
+    assert_equal %w[ queue_a2 queue_a2 queue_c1 queue_b1 queue_b1 queue_b2 queue_b2 queue_c2 queue_a1 queue_a1 ],
+      claimed_jobs.map(&:queue_name)
   end
 
   test "discard all" do


### PR DESCRIPTION
We were altering the original order to be exact names and then prefixes in the order returned by the DB, which doesn't need to be the order specified for the worker. This change ensures the order is respected. Besides this, this also documents a bit the performance implications of the different ways to specify queues per worker. 

This fixes #360. 