### PR TITLE
Add helper method to query the latency on the Queue object

### DIFF
--- a/app/models/solid_queue/queue.rb
+++ b/app/models/solid_queue/queue.rb
@@ -41,7 +41,7 @@ module SolidQueue
     end
 
     def latency
-      @latency = begin
+      @latency ||= begin
         now = Time.current
         oldest_enqueued_at = ReadyExecution.queued_as(name).minimum(:created_at) || now
 

--- a/app/models/solid_queue/queue.rb
+++ b/app/models/solid_queue/queue.rb
@@ -43,7 +43,7 @@ module SolidQueue
     def latency
       @latency = begin
         now = Time.current
-        oldest_enqueued_at = SolidQueue::ReadyExecution.queued_as(name).minimum(:created_at) || now
+        oldest_enqueued_at = ReadyExecution.queued_as(name).minimum(:created_at) || now
 
         (now - oldest_enqueued_at).to_i
       end

--- a/app/models/solid_queue/queue.rb
+++ b/app/models/solid_queue/queue.rb
@@ -40,6 +40,19 @@ module SolidQueue
       @size ||= ReadyExecution.queued_as(name).count
     end
 
+    def latency
+      @latency = begin
+        now = Time.current
+        oldest_enqueued_at = SolidQueue::ReadyExecution.queued_as(name).minimum(:created_at) || now
+
+        (now - oldest_enqueued_at).to_i
+      end
+    end
+
+    def human_latency
+      ActiveSupport::Duration.build(latency).inspect
+    end
+
     def ==(queue)
       name == queue.name
     end

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -48,16 +48,28 @@ class QueueTest < ActiveSupport::TestCase
     assert_in_delta 5.minutes.to_i, @background_queue.latency, 1.second.to_i
     assert_equal 0, @default_queue.latency
 
+    @background_queue = SolidQueue::Queue.find_by_name("background")
+    @default_queue = SolidQueue::Queue.find_by_name("default")
     travel_to 10.minutes.from_now
 
     assert_in_delta 15.minutes.to_i, @background_queue.latency, 1.second.to_i
     assert_equal 0, @default_queue.latency
   end
 
+  test "returns memoized latency after the first call" do
+    travel_to 5.minutes.from_now
+
+    assert_in_delta 5.minutes.to_i, @background_queue.latency, 1.second.to_i
+
+    travel_to 10.minutes.from_now
+
+    assert_in_delta 5.minutes.to_i, @background_queue.latency, 1.second.to_i
+  end
+
   test "return human latency on each queue" do
     travel_to 5.minutes.from_now
 
-    assert_match /5 minutes/, @background_queue.human_latency
-    assert_match /0 seconds/, @default_queue.human_latency
+    assert_match (/5 minutes/), @background_queue.human_latency
+    assert_match (/0 seconds/), @default_queue.human_latency
   end
 end

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class QueueTest < ActiveSupport::TestCase
   setup do
+    freeze_time
+
     5.times do
       AddToBufferJob.perform_later "hey!"
     end
@@ -38,5 +40,24 @@ class QueueTest < ActiveSupport::TestCase
     assert_changes -> { @default_queue.paused? }, from: true, to: false do
       @default_queue.resume
     end
+  end
+
+  test "return latency in seconds on each queue" do
+    travel_to 5.minutes.from_now
+
+    assert_in_delta 5.minutes.to_i, @background_queue.latency, 1.second.to_i
+    assert_equal 0, @default_queue.latency
+
+    travel_to 10.minutes.from_now
+
+    assert_in_delta 15.minutes.to_i, @background_queue.latency, 1.second.to_i
+    assert_equal 0, @default_queue.latency
+  end
+
+  test "return human latency on each queue" do
+    travel_to 5.minutes.from_now
+
+    assert_match /5 minutes/, @background_queue.human_latency
+    assert_match /0 seconds/, @default_queue.human_latency
   end
 end


### PR DESCRIPTION
Hey all!

I'm using Yabeda to collect some metrics on a rails app that uses solid_queue. I send some metrics like the latency on each queue. Currently I use a little patch to accomplish that. I wonder if we can upstream this path just to make it more convenient for other people to access solid_queue's API. 🤔 

My Yabeda config example

```rb
Yabeda.configure do
  group :solid_queue do
    gauge :queue_latency, unit: :seconds, tags: [:queue]
  end

  collect do
    SolidQueue::Queue.all.each do |queue|
      solid_queue.queue_latency.set({ queue: queue.name }, queue.latency)
    end
  end
end
```