### PR TITLE
Reimplement Interruptible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Folder for Visual Studio Code
 /.vscode/
 
+# Files for RVM holdouts
+.ruby-gemset
+
 # misc
 .DS_Store

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.3
   Exclude:
     - "test/dummy/db/schema.rb"
     - "test/dummy/db/queue_schema.rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     rake (13.2.1)
     rdoc (6.8.1)
       psych (>= 4.0.0)
+    rdoc (6.6.3.1)
+      psych (>= 4.0.0)
     regexp_parser (2.9.2)
     reline (0.5.12)
       io-console (~> 0.5)
@@ -192,6 +194,7 @@ DEPENDENCIES
   ostruct
   pg
   puma
+  rdoc
   rubocop-rails-omakase
   solid_queue!
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,14 +55,13 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.4.1)
-    debug (1.7.1)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
-    fiddle (1.1.2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -76,7 +75,7 @@ GEM
       reline (>= 0.4.2)
     json (2.8.2)
     language_server-protocol (3.17.0.3)
-    logger (1.6.0)
+    logger (1.6.2)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -93,7 +92,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -186,12 +184,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  debug
-  fiddle
+  debug (~> 1.9)
   logger
   mocha
   mysql2
-  ostruct
   pg
   puma
   rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
+    date (3.4.1)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -98,7 +99,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
-    psych (5.2.0)
+    psych (5.2.1)
+      date
       stringio
     puma (6.4.3)
       nio4r (~> 2.0)
@@ -129,8 +131,6 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rdoc (6.8.1)
-      psych (>= 4.0.0)
-    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
     reline (0.5.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    fiddle (1.1.2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -74,6 +75,7 @@ GEM
       reline (>= 0.4.2)
     json (2.8.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.0)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -90,6 +92,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -175,14 +178,18 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   debug
+  fiddle
+  logger
   mocha
   mysql2
+  ostruct
   pg
   puma
   rubocop-rails-omakase

--- a/lib/solid_queue/processes/interruptible.rb
+++ b/lib/solid_queue/processes/interruptible.rb
@@ -7,31 +7,25 @@ module SolidQueue::Processes
     end
 
     private
-      SELF_PIPE_BLOCK_SIZE = 11
 
       def interrupt
-        self_pipe[:writer].write_nonblock(".")
-      rescue Errno::EAGAIN, Errno::EINTR
-        # Ignore writes that would block and retry
-        # if another signal arrived while writing
-        retry
+        queue << true
       end
 
       def interruptible_sleep(time)
-        if time > 0 && self_pipe[:reader].wait_readable(time)
-          loop { self_pipe[:reader].read_nonblock(SELF_PIPE_BLOCK_SIZE) }
-        end
-      rescue Errno::EAGAIN, Errno::EINTR
+        # Since this is invoked on the main thread, using some form of Async
+        # avoids a 35% slowdown (at least when running the test suite).
+        #
+        # Using Futures for architectural consistency with all the other Async in SolidQueue.
+        Concurrent::Promises.future(time) do |timeout|
+          if timeout > 0 && queue.pop(timeout:)
+            queue.clear # exiting the poll wait guarantees testing for SHUTDOWN before next poll
+          end
+        end.value
       end
 
-      # Self-pipe for signal-handling (http://cr.yp.to/docs/selfpipe.html)
-      def self_pipe
-        @self_pipe ||= create_self_pipe
-      end
-
-      def create_self_pipe
-        reader, writer = IO.pipe
-        { reader: reader, writer: writer }
+      def queue
+        @queue ||= Queue.new
       end
   end
 end

--- a/lib/solid_queue/processes/interruptible.rb
+++ b/lib/solid_queue/processes/interruptible.rb
@@ -13,13 +13,11 @@ module SolidQueue::Processes
       end
 
       def interruptible_sleep(time)
-        # Since this is invoked on the main thread, using some form of Async
-        # avoids a 35% slowdown (at least when running the test suite).
-        #
-        # Using Futures for architectural consistency with all the other Async in SolidQueue.
+        # Invoking from the main thread can result in a 35% slowdown (at least when running the test suite).
+        # Using some form of Async (Futures) addresses this performance issue.
         Concurrent::Promises.future(time) do |timeout|
           if timeout > 0 && queue.pop(timeout:)
-            queue.clear # exiting the poll wait guarantees testing for SHUTDOWN before next poll
+            queue.clear
           end
         end.value
       end

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ostruct"
   spec.add_development_dependency "logger"
   spec.add_development_dependency "fiddle"
+  spec.add_development_dependency "rdoc"
 end

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -44,4 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rubocop-rails-omakase"
+  spec.add_development_dependency "ostruct"
+  spec.add_development_dependency "logger"
+  spec.add_development_dependency "fiddle"
 end

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -37,15 +37,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fugit", "~> 1.11.0"
   spec.add_dependency "thor", "~> 1.3.1"
 
-  spec.add_development_dependency "debug"
+  spec.add_development_dependency "debug", "~> 1.9"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "puma"
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rubocop-rails-omakase"
-  spec.add_development_dependency "ostruct"
-  spec.add_development_dependency "logger"
-  spec.add_development_dependency "fiddle"
   spec.add_development_dependency "rdoc"
+  spec.add_development_dependency "logger"
 end

--- a/test/dummy/config/initializers/enable_yjit.rb
+++ b/test/dummy/config/initializers/enable_yjit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Ideally, tests should be configured as close to production settings as
+# possible and YJIT is likely to be enabled. While it's highly unlikely
+# YJIT would cause issues, enabling it confirms this assertion.
+#
+# Configured via initializer to align with Rails 7.1 default in gemspec
+if defined?(RubyVM::YJIT.enable)
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end

--- a/test/integration/concurrency_controls_test.rb
+++ b/test/integration/concurrency_controls_test.rb
@@ -85,7 +85,7 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
   test "run several jobs over the same record sequentially, with some of them failing" do
     ("A".."F").each_with_index do |name, i|
       # A, C, E will fail, for i= 0, 2, 4
-      SequentialUpdateResultJob.perform_later(@result, name: name, pause: 0.2.seconds, exception: (RuntimeError if i.even?))
+      SequentialUpdateResultJob.perform_later(@result, name: name, pause: 0.2.seconds, exception: (ExpectedTestError if i.even?))
     end
 
     ("G".."K").each do |name|

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -162,7 +162,7 @@ class InstrumentationTest < ActiveSupport::TestCase
 
   test "errors when deregistering processes are included in deregister_process events" do
     previous_thread_report_on_exception, Thread.report_on_exception = Thread.report_on_exception, false
-    error = RuntimeError.new("everything is broken")
+    error = ExpectedTestError.new("everything is broken")
     SolidQueue::Process.any_instance.expects(:destroy!).raises(error).at_least_once
 
     events = subscribed("deregister_process.solid_queue") do
@@ -182,7 +182,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "retrying failed job emits retry event" do
-    RaisingJob.perform_later(RuntimeError, "A")
+    RaisingJob.perform_later(ExpectedTestError, "A")
     job = SolidQueue::Job.last
 
     worker = SolidQueue::Worker.new.tap(&:start)
@@ -198,7 +198,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "retrying failed jobs in bulk emits retry_all" do
-    3.times { RaisingJob.perform_later(RuntimeError, "A") }
+    3.times { RaisingJob.perform_later(ExpectedTestError, "A") }
     AddToBufferJob.perform_later("A")
 
     jobs = SolidQueue::Job.last(4)
@@ -392,7 +392,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   test "thread errors emit thread_error events" do
     previous_thread_report_on_exception, Thread.report_on_exception = Thread.report_on_exception, false
 
-    error = RuntimeError.new("everything is broken")
+    error = ExpectedTestError.new("everything is broken")
     SolidQueue::ClaimedExecution::Result.expects(:new).raises(error).at_least_once
 
     AddToBufferJob.perform_later "hey!"

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -144,11 +144,11 @@ class ProcessesLifecycleTest < ActiveSupport::TestCase
   test "process some jobs that raise errors" do
     2.times { enqueue_store_result_job("no error", :background) }
     2.times { enqueue_store_result_job("no error", :default) }
-    error1 = enqueue_store_result_job("error", :background, exception: RuntimeError)
+    error1 = enqueue_store_result_job("error", :background, exception: ExpectedTestError)
     enqueue_store_result_job("no error", :background, pause: 0.03)
-    error2 = enqueue_store_result_job("error", :background, exception: RuntimeError, pause: 0.05)
+    error2 = enqueue_store_result_job("error", :background, exception: ExpectedTestError, pause: 0.05)
     2.times { enqueue_store_result_job("no error", :default, pause: 0.01) }
-    error3 = enqueue_store_result_job("error", :default, exception: RuntimeError)
+    error3 = enqueue_store_result_job("error", :default, exception: ExpectedTestError)
 
     wait_for_jobs_to_finish_for(2.second, except: [ error1, error2, error3 ])
 


### PR DESCRIPTION
Details for each of the commits are in the separate commit messages

- Some minor housekeeping with .gitignore, .rubocop.ymlt and solid_queue.gemspec
- Proposed update to the tests to silence successful tests from outputting backtraces (keep the test output clean where possible and only output for the unexpected 
- Proposed reimplementation of the Interruptible concern to help mitigate some mysql database connectivity issues.