### PR TITLE
Don't add `solid_queue.connects_to` configuration more than once

### DIFF
--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -11,9 +11,11 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
     chmod "bin/jobs", 0755 & ~File.umask, verbose: false
   end
 
-  def configure_active_job_adapter
-    gsub_file Pathname(destination_root).join("config/environments/production.rb"),
-      /(# )?config\.active_job\.queue_adapter\s+=.*/,
+  def configure_adapter_and_database
+    pathname = Pathname(destination_root).join("config/environments/production.rb")
+
+    gsub_file pathname, /\n\s*config\.solid_queue\.connects_to\s+=.*\n/, "\n", verbose: false
+    gsub_file pathname, /(# )?config\.active_job\.queue_adapter\s+=.*\n/,
       "config.active_job.queue_adapter = :solid_queue\n" +
       "  config.solid_queue.connects_to = { database: { writing: :queue } }\n"
   end


### PR DESCRIPTION
Or, in other words, make the install generator idempotent.

Inspired by #349