### PR TITLE
Specialize Dispatcher and Worker looping

### DIFF
--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -24,7 +24,8 @@ module SolidQueue
     private
       def poll
         batch = dispatch_next_batch
-        batch.size
+
+        batch.size.zero? ? polling_interval : 0.seconds
       end
 
       def dispatch_next_batch

--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -25,11 +25,11 @@ module SolidQueue::Processes
         loop do
           break if shutting_down?
 
-          wrap_in_app_executor do
-            unless poll > 0
-              interruptible_sleep(polling_interval)
-            end
+          delay = wrap_in_app_executor do
+            poll
           end
+
+          interruptible_sleep(delay)
         end
       ensure
         SolidQueue.instrument(:shutdown_process, process: self) do

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -7,6 +7,7 @@ module SolidQueue
     after_boot :run_start_hooks
     before_shutdown :run_stop_hooks
 
+
     attr_accessor :queues, :pool
 
     def initialize(**options)
@@ -29,7 +30,7 @@ module SolidQueue
             pool.post(execution)
           end
 
-          executions.size
+          pool.idle? ? polling_interval : 10.minutes
         end
       end
 


### PR DESCRIPTION
The Worker and Dispatcher share the same poll loop logic (Poller#start_loop) while having different functional requirements. The Worker is polling despite not being able to execute new jobs if at capacity. The Dispatcher does require polling, but is reliant on shared logic in Poller#start_loop for a Dispatcher specific optimization.
 
This PR allows the Worker to switch from polling to wake-on-event when its at capacity and eliminates the overhead of Worker#poll (really Worker#claim_executions) when it's known ahead of time #poll will be a no-op.

Changes:
    
Move the logic controlling the sleep interval from Poller#start_loop into Worker#poll and Dispatcher#poll by requiring #poll to return the `delay` value passed into interruptible_sleep.
    
Poller#start_loop:

- Removes the test based on the number of rows processed by #poll. This was Dispatcher specific logic.

Worker#poll:

- When Worker at full capacity: return a large value (10.minutes) effectively transforming Poller#start_loop from polling to wake-on-event.
- When Worker < capacity: return `polling_interval` and maintain the poll timing until ReadyExecutions become available.

Dispatcher#poll:

- When `due` ScheduledExecutions < batch_size: return `polling_interval` and maintain the existing poll timing.
- When `due` ScheduledExecutions >= batch_size: return 0 and do not sleep between loops until all `due` ScheduledExecutions are processed. Loop via poll requests with sleep 0 (instead of simple loop in #poll) to check for shutdown requests between loops.
