### PR TITLE
Specify `source` of SolidQueue to ErrorReporter

### DIFF
--- a/lib/solid_queue/app_executor.rb
+++ b/lib/solid_queue/app_executor.rb
@@ -4,7 +4,7 @@ module SolidQueue
   module AppExecutor
     def wrap_in_app_executor(&block)
       if SolidQueue.app_executor
-        SolidQueue.app_executor.wrap(&block)
+        SolidQueue.app_executor.wrap(source: "application.solid_queue", &block)
       else
         yield
       end


### PR DESCRIPTION
Currently, the default value `application.active_support` is applied for source. This does not identify it as an exception raised inside SolidQueue.

> source: a String about the source of the error. The default source is "application". Errors reported by internal libraries may set other sources; the Redis cache library may use "redis_cache_store.active_support", for instance. Your subscriber can use the source to ignore errors you aren't interested in.

This is a quote from the [rails guide](https://github.com/rails/rails/blob/v8.0.0/guides/source/error_reporting.md?plain=1#L216-L220).

Follow this guide to specify the source so that it can be determined that the error originated from inside SolidQueue.

Fixes #446