### PR TITLE
Set `RAILS_MAX_THREADS` as the default number of worker threads

### DIFF
--- a/lib/generators/solid_queue/install/templates/config/queue.yml
+++ b/lib/generators/solid_queue/install/templates/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: <%= ENV.fetch("RAILS_MAX_THREADS", 3) %>
       processes: <%%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 


### PR DESCRIPTION
The number of worker threads in solid_queue must be less than or equal to the size of the database connection pool.
Otherwise, the worker threads might get stuck while trying to obtain a connection from the pool.

Rails sets `RAILS_MAX_THREADS` as the default size of the database connection pool:

* [PostgreSQL configuration](https://github.com/rails/rails/blob/7e06191d33ace40063543f8d3732db87fbf247f5/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L20)
* [MySQL configuration](https://github.com/rails/rails/blob/7e06191d33ace40063543f8d3732db87fbf247f5/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt#L15)
* [SQLite3 configuration](https://github.com/rails/rails/blob/7e06191d33ace40063543f8d3732db87fbf247f5/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt#L9)
* [Trilogy configuration](https://github.com/rails/rails/blob/7e06191d33ace40063543f8d3732db87fbf247f5/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt#L15)

Therefore, we should set `RAILS_MAX_THREADS` as the default number of threads for solid_queue.

If the `RAILS_MAX_THREADS` environment variable is not set, `3` will be a good default value because `puma.rb` also uses `3` as the default number of worker threads.
* [Default Puma configuration](https://github.com/rails/rails/blob/7e06191d33ace40063543f8d3732db87fbf247f5/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L28)