### PR TITLE
Update Pool from Future to Concurrent::Promises

### DIFF
--- a/lib/solid_queue/pool.rb
+++ b/lib/solid_queue/pool.rb
@@ -18,20 +18,16 @@ module SolidQueue
     def post(execution)
       available_threads.decrement
 
-      future = Concurrent::Future.new(args: [ execution ], executor: executor) do |thread_execution|
+      Concurrent::Promises.future_on(executor, execution) do |thread_execution|
         wrap_in_app_executor do
           thread_execution.perform
         ensure
           available_threads.increment
           mutex.synchronize { on_idle.try(:call) if idle? }
         end
+      end.on_rejection! do |e|
+        handle_thread_error(e)
       end
-
-      future.add_observer do |_, _, error|
-        handle_thread_error(error) if error
-      end
-
-      future.execute
     end
 
     def idle_threads


### PR DESCRIPTION
This PR updates SolidQueue::Pool from the deprecated Concurrent::Future to the more "promising" (sorry) Concurrent::Promises API.

Rational:
The Promises based API is documented as preferred over the Future API. Concurrent::Promises are more performant and deadlock resistant -- Good Things(tm) for SolidQueue.

Given Concurrent::Promises where released 2018, there is little "new" or "not battle tested" risk with this change.