### PR TITLE
Don't fail when recurring tasks are defined for another environment

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -141,8 +141,8 @@ module SolidQueue
 
       def recurring_tasks
         @recurring_tasks ||= recurring_tasks_config.map do |id, options|
-          RecurringTask.from_configuration(id, **options)
-        end
+          RecurringTask.from_configuration(id, **options) if options.has_key?(:schedule)
+        end.compact
       end
 
       def processes_config

--- a/test/dummy/config/recurring_with_production_only.yml
+++ b/test/dummy/config/recurring_with_production_only.yml
@@ -1,0 +1,6 @@
+production:
+  periodic_store_result:
+    class: StoreResultJob
+    queue: default
+    args: [ 42, { status: "custom_status" } ]
+    schedule: every second

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -99,6 +99,10 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert SolidQueue::Configuration.new(recurring_schedule_file: config_file_path(:empty_recurring)).valid?
     assert SolidQueue::Configuration.new(skip_recurring: true).valid?
 
+    configuration = SolidQueue::Configuration.new(recurring_schedule_file: config_file_path(:recurring_with_production_only))
+    assert configuration.valid?
+    assert_processes configuration, :scheduler, 0
+
     # No processes
     configuration = SolidQueue::Configuration.new(skip_recurring: true, dispatchers: [], workers: [])
     assert_not configuration.valid?


### PR DESCRIPTION
For example, `production` only, and the configuration is being loaded for `development`. In this case, we can't take the env key as the task definition, failing to load Solid Queue at all.

Fixes https://github.com/rails/solid_queue/issues/468