### PR TITLE
Fix case where a recurring task key is empty in the config

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -141,7 +141,7 @@ module SolidQueue
 
       def recurring_tasks
         @recurring_tasks ||= recurring_tasks_config.map do |id, options|
-          RecurringTask.from_configuration(id, **options) if options.has_key?(:schedule)
+          RecurringTask.from_configuration(id, **options) if options&.has_key?(:schedule)
         end.compact
       end
 
@@ -153,7 +153,9 @@ module SolidQueue
       end
 
       def recurring_tasks_config
-        @recurring_tasks_config ||= config_from options[:recurring_schedule_file]
+        @recurring_tasks_config ||= begin
+          config_from options[:recurring_schedule_file]
+        end
       end
 
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -103,6 +103,10 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert configuration.valid?
     assert_processes configuration, :scheduler, 0
 
+    configuration = SolidQueue::Configuration.new(recurring_schedule_file: config_file_path(:recurring_with_empty))
+    assert configuration.valid?
+    assert_processes configuration, :scheduler, 0
+
     # No processes
     configuration = SolidQueue::Configuration.new(skip_recurring: true, dispatchers: [], workers: [])
     assert_not configuration.valid?


### PR DESCRIPTION
For example, when there's an entry for an environment other than the current one being used and that one is empty.