### PR TITLE
chore: Updates README to include small addition of plus for development multi db

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For example, if you're using SQLite in development, update `database.yml` as fol
 
 ```diff
 development:
-  primary:
++ primary:
     <<: *default
     database: storage/development.sqlite3
 +  queue:


### PR DESCRIPTION
In doing a fresh setup with Rails 8, I followed the instructions but missed the fact that in the fresh install Rails doesn't include a `primary` key for the `development` database. 

This is likely because `solid_queue` isn't necessary in development. In the instructions to setup the multi-db in development, however, I missed the small addition due to the lack of `diff` addition. 

This PR makes it a bit more clear for folks that you need the `primary` key in addition to the `queue` key. Otherwise, it seems like Rails just ignores the `queue` key.
