### PR TITLE
Require Ruby v3.1+

### DIFF
--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   rails_version = ">= 7.1"
+  spec.required_ruby_version = '>= 3.1'
   spec.add_dependency "activerecord", rails_version
   spec.add_dependency "activejob", rails_version
   spec.add_dependency "railties", rails_version


### PR DESCRIPTION
When attempting to install SQ 1.1.2 on a Ubuntu 22.04LTS system with default ruby (3.0.5) and Rails 7.1 it fails with the following error:

```
SyntaxError: /usr/lib/ruby/gems/3.0.0/gems/solid_queue-1.1.2/lib/solid_queue/processes/interruptible.rb:25: syntax error, unexpected ')'
          queue.pop(timeout:).tap { queue.clear }
```

Using Ruby 3.1 there's no such error. It therefore seems that the gemspec should specify Ruby 3.1 as the minimum ruby version and not just Rails 7.1.