### PR TITLE
feat: add on_exit hook

### DIFF
--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -8,7 +8,8 @@ module SolidQueue
     after_boot :run_start_hooks
     after_boot :start_concurrency_maintenance
     before_shutdown :stop_concurrency_maintenance
-    after_shutdown :run_stop_hooks
+    before_shutdown :run_stop_hooks
+    after_shutdown :run_exit_hooks
 
     def initialize(**options)
       options = options.dup.with_defaults(SolidQueue::Configuration::DISPATCHER_DEFAULTS)

--- a/lib/solid_queue/lifecycle_hooks.rb
+++ b/lib/solid_queue/lifecycle_hooks.rb
@@ -5,7 +5,7 @@ module SolidQueue
     extend ActiveSupport::Concern
 
     included do
-      mattr_reader :lifecycle_hooks, default: { start: [], stop: [] }
+      mattr_reader :lifecycle_hooks, default: { start: [], stop: [], exit: [] }
     end
 
     class_methods do
@@ -17,7 +17,12 @@ module SolidQueue
         self.lifecycle_hooks[:stop] << block
       end
 
+      def on_exit(&block)
+        self.lifecycle_hooks[:exit] << block
+      end
+
       def clear_hooks
+        self.lifecycle_hooks[:exit] = []
         self.lifecycle_hooks[:start] = []
         self.lifecycle_hooks[:stop] = []
       end
@@ -30,6 +35,10 @@ module SolidQueue
 
       def run_stop_hooks
         run_hooks_for :stop
+      end
+
+      def run_exit_hooks
+        run_hooks_for :exit
       end
 
       def run_hooks_for(event)

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -11,6 +11,7 @@ module SolidQueue
     after_boot :schedule_recurring_tasks
     before_shutdown :unschedule_recurring_tasks
     before_shutdown :run_stop_hooks
+    after_shutdown :run_exit_hooks
 
     def initialize(recurring_tasks:, **options)
       @recurring_schedule = RecurringSchedule.new(recurring_tasks)

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -5,6 +5,8 @@ module SolidQueue
     include LifecycleHooks
     include Maintenance, Signals, Pidfiled
 
+    after_shutdown :run_exit_hooks
+
     class << self
       def start(**options)
         SolidQueue.supervisor = true

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -6,7 +6,7 @@ module SolidQueue
 
     after_boot :run_start_hooks
     before_shutdown :run_stop_hooks
-
+    after_shutdown :run_exit_hooks
 
     attr_accessor :queues, :pool
 


### PR DESCRIPTION
Expose new `on_exit` hook to allow post-shutdown cleanup actions.

Notes:
- I made it for all kind of processes, but I believe it would only be useful for workers as they are the only one that may require such hooks. Do you believe it should only be for workers now and add them for the others later?
- Dispatchers currently trigger `run_stop_hooks` in [after_shutdown](https://github.com/rails/solid_queue/blob/cb5d230ddbf6732f2b78a5d3748475bab3b1deb5/lib/solid_queue/dispatcher.rb#L11)  but workers trigger them at [before_shutdown](https://github.com/rails/solid_queue/blob/cb5d230ddbf6732f2b78a5d3748475bab3b1deb5/lib/solid_queue/worker.rb#L8), I changed it in this PR but was that the expected behavior?