### PR TITLE
Have all processes yield self to lifecycle hooks

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -45,15 +45,15 @@ module SolidQueue
 
   [ Dispatcher, Scheduler, Worker ].each do |process|
     define_singleton_method(:"on_#{process.name.demodulize.downcase}_start") do |&block|
-      process.on_start { block.call }
+      process.on_start(&block)
     end
 
     define_singleton_method(:"on_#{process.name.demodulize.downcase}_stop") do |&block|
-      process.on_stop { block.call }
+      process.on_stop(&block)
     end
 
     define_singleton_method(:"on_#{process.name.demodulize.downcase}_exit") do |&block|
-      process.on_exit { block.call }
+      process.on_exit(&block)
     end
   end
 

--- a/lib/solid_queue/dispatcher.rb
+++ b/lib/solid_queue/dispatcher.rb
@@ -3,7 +3,7 @@
 module SolidQueue
   class Dispatcher < Processes::Poller
     include LifecycleHooks
-    attr_accessor :batch_size, :concurrency_maintenance
+    attr_reader :batch_size
 
     after_boot :run_start_hooks
     after_boot :start_concurrency_maintenance
@@ -26,6 +26,8 @@ module SolidQueue
     end
 
     private
+      attr_reader :concurrency_maintenance
+
       def poll
         batch = dispatch_next_batch
 

--- a/lib/solid_queue/lifecycle_hooks.rb
+++ b/lib/solid_queue/lifecycle_hooks.rb
@@ -43,7 +43,7 @@ module SolidQueue
 
       def run_hooks_for(event)
         self.class.lifecycle_hooks.fetch(event, []).each do |block|
-          block.call
+            block.call(self)
         rescue Exception => exception
           handle_thread_error(exception)
         end

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -5,7 +5,7 @@ module SolidQueue
     include Processes::Runnable
     include LifecycleHooks
 
-    attr_accessor :recurring_schedule
+    attr_reader :recurring_schedule
 
     after_boot :run_start_hooks
     after_boot :schedule_recurring_tasks

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -8,12 +8,14 @@ module SolidQueue
     before_shutdown :run_stop_hooks
     after_shutdown :run_exit_hooks
 
-    attr_accessor :queues, :pool
+    attr_reader :queues, :pool
 
     def initialize(**options)
       options = options.dup.with_defaults(SolidQueue::Configuration::WORKER_DEFAULTS)
 
-      @queues = Array(options[:queues])
+      # Ensure that the queues array is deep frozen to prevent accidental modification
+      @queues = Array(options[:queues]).map(&:freeze).freeze
+
       @pool = Pool.new(options[:threads], on_idle: -> { wake_up })
 
       super(**options)


### PR DESCRIPTION
Makes it so that Workers will yield self to life cycle hooks and makes some adjustments related to what's public/private in them.

I did not do this for the dispatcher or supervisor as I felt that did not make sense.

closes #513