### PR TITLE
Fix README queues config value to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ and then remove the paused ones. Pausing in general should be something rare, us
 Do this:
 
 ```yml
-queues: background, backend
+queues: [ background, backend ]
 ```
 
 instead of this:


### PR DESCRIPTION
Small PR since I have noticed [this](https://github.com/rails/solid_queue/issues/67) issue already, following by by the [fix](https://github.com/rails/solid_queue/commit/7838ad4bcb1efeac7179065d780410df31879b74), but I think this was unintentionally omitted.