### PR TITLE
Add capability to discard duplicate jobs with concurrency configuration

### DIFF
--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -65,7 +65,8 @@ module SolidQueue
       end
 
       def dispatch
-        if acquire_concurrency_lock then ready
+        if discard_on_duplicate? then discard
+        elsif acquire_concurrency_lock then ready
         else
           block
         end

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -10,6 +10,10 @@ module SolidQueue
         Proxy.new(job).wait
       end
 
+      def at_limit?(job)
+        Proxy.new(job).at_limit?
+      end
+
       def signal(job)
         Proxy.new(job).signal
       end
@@ -37,6 +41,14 @@ module SolidQueue
 
       def initialize(job)
         @job = job
+      end
+
+      def at_limit?
+        if semaphore = Semaphore.find_by(key: key)
+          semaphore.value.zero?
+        else
+          false
+        end
       end
 
       def wait

--- a/lib/active_job/concurrency_controls.rb
+++ b/lib/active_job/concurrency_controls.rb
@@ -11,15 +11,17 @@ module ActiveJob
       class_attribute :concurrency_group, default: DEFAULT_CONCURRENCY_GROUP, instance_accessor: false
 
       class_attribute :concurrency_limit
+      class_attribute :concurrency_on_duplicate
       class_attribute :concurrency_duration, default: SolidQueue.default_concurrency_control_period
     end
 
     class_methods do
-      def limits_concurrency(key:, to: 1, group: DEFAULT_CONCURRENCY_GROUP, duration: SolidQueue.default_concurrency_control_period)
+      def limits_concurrency(key:, to: 1, group: DEFAULT_CONCURRENCY_GROUP, duration: SolidQueue.default_concurrency_control_period, on_duplicate: :block)
         self.concurrency_key = key
         self.concurrency_limit = to
         self.concurrency_group = group
         self.concurrency_duration = duration
+        self.concurrency_on_duplicate = on_duplicate
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/rails/solid_queue/issues/176

Add ability to discard duplicate jobs instead of becoming blocked. When configuring `concurrency_limits` with `on_duplicate: discard` jobs scheduled above the concurrency limit are discarded and not executed.

## Implementation Details

* adds class_attribute `concurrency_on_duplicate` and `on_duplicate` option to `concurrency_limits`
* adds methods to Semaphore to detect when a job would be above the concurrency limit
* adds logic to discard a job on dispatch when above concurrency limit