### PR TITLE
Pass job.id to the executing job as provider_job_id for access within perform()

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -92,7 +92,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
 
   private
     def execute
-      ActiveJob::Base.execute(job.arguments)
+      ActiveJob::Base.execute(job.arguments.merge(provider_job_id: job.id))
       Result.new(true, nil)
     rescue Exception => e
       Result.new(false, e)

--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -92,7 +92,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
 
   private
     def execute
-      ActiveJob::Base.execute(job.arguments.merge(provider_job_id: job.id))
+      ActiveJob::Base.execute(job.arguments.merge("provider_job_id" => job.id))
       Result.new(true, nil)
     rescue Exception => e
       Result.new(false, e)

--- a/test/dummy/app/jobs/provider_job_id_job.rb
+++ b/test/dummy/app/jobs/provider_job_id_job.rb
@@ -1,0 +1,5 @@
+class ProviderJobIdJob < ApplicationJob
+  def perform
+    JobBuffer.add "provider_job_id: #{provider_job_id}"
+  end
+end

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -73,6 +73,14 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
     assert job.reload.failed?
   end
 
+  test "provider_job_id is available within job execution" do
+    job = ProviderJobIdJob.perform_later
+    claimed_execution = prepare_and_claim_job job
+    claimed_execution.perform
+
+    assert_equal "provider_job_id: #{job.provider_job_id}", JobBuffer.last_value
+  end
+
   private
     def prepare_and_claim_job(active_job, process: @process)
       job = SolidQueue::Job.find_by(active_job_id: active_job.job_id)


### PR DESCRIPTION
Sometimes it's handy to have `provider_job_id` available within `perform`. The Sidekiq adapter does it and Rails allows for it:

https://github.com/rails/rails/blob/aa2bfad1a137c9add1b35de118b391494e13ca06/activejob/lib/active_job/core.rb#L35

So far I'm not sure how to test this and the suite doesn't appear to go so far as testing the execution of jobs or at least what is available within `perform()`. Some guidance would be much appreciated :)

Closes #514