### PR TITLE
Add default key for limits_concurrency

### DIFF
--- a/lib/active_job/concurrency_controls.rb
+++ b/lib/active_job/concurrency_controls.rb
@@ -5,6 +5,7 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     DEFAULT_CONCURRENCY_GROUP = ->(*) { self.class.name }
+    DEFAULT_CONCURRENCY_KEY = ->(*) { nil }
 
     included do
       class_attribute :concurrency_key, instance_accessor: false
@@ -15,7 +16,7 @@ module ActiveJob
     end
 
     class_methods do
-      def limits_concurrency(key:, to: 1, group: DEFAULT_CONCURRENCY_GROUP, duration: SolidQueue.default_concurrency_control_period)
+      def limits_concurrency(key: DEFAULT_CONCURRENCY_KEY, to: 1, group: DEFAULT_CONCURRENCY_GROUP, duration: SolidQueue.default_concurrency_control_period)
         self.concurrency_key = key
         self.concurrency_limit = to
         self.concurrency_group = group


### PR DESCRIPTION
Hi, this PR adds a default key to `limits_concurrency` so users don't need to come up with a key name if they only want to limit by job name (regardless of arguments), which I expect is a common case.

```ruby
class SomeJob < ApplicationJob
  limits_concurrency to: 3
end
```

Currently, users must use an empty string or another key.

```ruby
class SomeJob < ApplicationJob
  limits_concurrency key: "", to: 3
end
```

