### PR TITLE
Automatically clean-up old, finished background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ There are several settings that control how Solid Queue works that you can set a
 - `silence_polling`: whether to silence Active Record logs emitted when polling for both workers and dispatchers—defaults to `true`.
 - `supervisor_pidfile`: path to a pidfile that the supervisor will create when booting to prevent running more than one supervisor in the same host, or in case you want to use it for a health check. It's `nil` by default.
 - `preserve_finished_jobs`: whether to keep finished jobs in the `solid_queue_jobs` table—defaults to `true`.
-- `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true—defaults to 1 day. **Note:** Right now, there's no automatic cleanup of finished jobs. You'd need to do this by periodically invoking `SolidQueue::Job.clear_finished_in_batches`, which can be configured as [a recurring task](#recurring-tasks).
+- `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true — defaults to 1 day. **Note:** `SolidQueue` automatically cleans up the finished jobs at 1 AM. To disable this, remove the `automatically_cleanup_finished_jobs` periodic job from the `recurring.yml` configuration.
 - `default_concurrency_control_period`: the value to be used as the default for the `duration` parameter in [concurrency controls](#concurrency-controls). It defaults to 3 minutes.
 
 

--- a/lib/generators/solid_queue/install/templates/config/recurring.yml
+++ b/lib/generators/solid_queue/install/templates/config/recurring.yml
@@ -8,3 +8,8 @@
 #     command: "SoftDeletedRecord.due.delete_all"
 #     priority: 2
 #     schedule: at 5am every day
+production:
+  automatically_cleanup_finished_jobs:
+    class: SolidQueue::Job.clear_finished_in_batches
+    queue: default
+    schedule: at 1am every day


### PR DESCRIPTION
This PR is a suggestion to automatically clean up old, finished background jobs. This prevents people from shooting themselves in the foot as I did. 

See the discussion here: https://github.com/rails/solid_queue/issues/560.