### PR TITLE
feat: add recurring cleanup job to generator

### DIFF
--- a/lib/generators/solid_queue/install/templates/config/recurring.yml
+++ b/lib/generators/solid_queue/install/templates/config/recurring.yml
@@ -8,3 +8,10 @@
 #     command: "SoftDeletedRecord.due.delete_all"
 #     priority: 2
 #     schedule: at 5am every day
+#
+#   Right now, there's no automatic cleanup of finished jobs.
+#   This reccuring job will clean up jobs older than the
+#   `clear_finished_jobs_after` period which defaults to 1 day.
+#   finished_job_cleanup:
+#     command: "SolidQueue::Job.clear_finished_in_batches"
+#     schedule: at 2am every day


### PR DESCRIPTION
## Motivation

At my work we have been trying to unify our applications on solid queue for background job processing and we found pretty consistently that when developers were setting it up they did not realize that they would need to schedule a job to clear out finished jobs. (I only learned about this when I had 12M finished jobs and my dashboard had slowed to a crawl).

Its not immediately clear that finished jobs need to be cleaned up or that solid queue has a built in way to do that. The only mention of this in the README is part of a bullet under [additional config](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings).

## Implementation

I think adding a note and implementation of this behavior directly to the `recurring.yml` that is generated when installing would make it a lot easier for developers to realize that they may need to add this recurring job.