### PR TITLE
feat: update supported ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,21 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - 3.1.6
         - 3.2.0
-        - 3.2.4
+        - 3.2.8
         - 3.3.0
         - 3.3.1
         - 3.3.2
         - 3.3.4
         - 3.3.5
         - 3.3.6
+        - 3.3.7
+        - 3.3.8
         - 3.4.0
         - 3.4.1
+        - 3.4.2
+        - 3.4.3
+        - 3.4.4
         database: [ mysql, postgres, sqlite ]
     services:
       mysql:

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "UPGRADING.md"]
   end
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   rails_version = ">= 7.1"
   spec.add_dependency "activerecord", rails_version


### PR DESCRIPTION
- Drops support for Ruby 3.1 since it is EOL.
- Tests only first and last versions of 3.2.*
- Tests all current versions of Ruby 3.3.* and 3.4.*