### PR TITLE
fix: race condition with interruptibles

### DIFF
--- a/lib/solid_queue/processes/base.rb
+++ b/lib/solid_queue/processes/base.rb
@@ -4,7 +4,8 @@ module SolidQueue
   module Processes
     class Base
       include Callbacks # Defines callbacks needed by other concerns
-      include AppExecutor, Registrable, Interruptible, Procline
+      include AppExecutor, Registrable, Procline
+      prepend Interruptible
 
       attr_reader :name
 

--- a/lib/solid_queue/processes/interruptible.rb
+++ b/lib/solid_queue/processes/interruptible.rb
@@ -2,6 +2,13 @@
 
 module SolidQueue::Processes
   module Interruptible
+    attr_reader :self_pipe
+
+    def initialize(...)
+      super
+      @self_pipe = create_self_pipe
+    end
+
     def wake_up
       interrupt
     end
@@ -25,10 +32,6 @@ module SolidQueue::Processes
       end
 
       # Self-pipe for signal-handling (http://cr.yp.to/docs/selfpipe.html)
-      def self_pipe
-        @self_pipe ||= create_self_pipe
-      end
-
       def create_self_pipe
         reader, writer = IO.pipe
         { reader: reader, writer: writer }


### PR DESCRIPTION
## The Problem

When running `TARGET_DB=sqlite bin/rails test --seed 38423` I consistently had failures like:

```sh
Failure:
LifecycleHooksTest#test_run_lifecycle_hooks [test/integration/lifecycle_hooks_test.rb:90]:
Expected: 15
  Actual: 13
```

I believe these failures are not sqlite exclusive but are more noticeable there cause it was not running in docker.

The test:
- sets a bunch of lifecycle hooks `SolidQueue.on_scheduler_start  {...}`
- runs the supervisor `pid  = run_supervisor_as_fork(...)`
- terminates the supervisor `terminate_process(pid)`
- then checks that the `JobResults` from the callbacks were created

Instead of the Scheduler receiving the `TERM` signal, gracefully shutting down and running callbacks it would not do anything in response to the signal, hit the timeout, receive a `KILL` signal and not run the callbacks. 

## Race Condition

It seems like the issue was `self_pipe` being slow:

```rb
def self_pipe
  @self_pipe ||= create_self_pipe
end

def create_self_pipe
  reader, writer = IO.pipe
  { reader: reader, writer: writer }
end
```

One thread would call [`run`](https://github.com/rails/solid_queue/blob/0ee21e49de3bbadf1c72294cdbadf12978486d6c/lib/solid_queue/scheduler.rb#L29) and while it was creating the pipe another thread would call [`stop`](https://github.com/rails/solid_queue/blob/0ee21e49de3bbadf1c72294cdbadf12978486d6c/lib/solid_queue/processes/runnable.rb#L19). 

This is a race condition. Both threads end up creating their own pipes and when [`interrupt`](https://github.com/rails/solid_queue/blob/0ee21e49de3bbadf1c72294cdbadf12978486d6c/lib/solid_queue/processes/interruptible.rb#L12) writes to the pipe the does not go anywhere cause the other thread has a different pipe.

```
Thread A: #run
Thread A: #self_pipe
Thread B: #stop
Thread B: #self_pipe
Thread B: #self_pipe => {reader: #<IO:fd 65>, writer: #<IO:fd 66>}
Thread B: #interrupt => #<IO:fd 66>
Thread A: #self_pipe => {reader: #<IO:fd 63>, writer: #<IO:fd 64>}
Thread B: done => killing thread
Thread A: #interruptible_sleep => #<IO:fd 63>
```

If this race condition happens Thread A will sleep until it gets killed.

## Solution

I ended up fixing this by getting rid of the lazy initialization of the pipe. That way any thread that is accessing the same scheduler will have the same pipe. 

Alternatively maybe there should be a Mutex around the setter for `self_pipe`.

