### PR TITLE
fix(568): moving stop_heartbeat after shutdown 

### DIFF
--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -7,8 +7,7 @@ module SolidQueue::Processes
     included do
       after_boot :register, :launch_heartbeat
 
-      before_shutdown :stop_heartbeat
-      after_shutdown :deregister
+      after_shutdown :stop_heartbeat, :deregister
     end
 
     def process_id


### PR DESCRIPTION
Moving stop_heartbeat after shutdown so that workers are not considered dead during a graceful shutdown.

Details in https://github.com/rails/solid_queue/issues/568