### PR TITLE
rescue from EWOULDBLOCKWaitReadable

### DIFF
--- a/lib/solid_queue/processes/interruptible.rb
+++ b/lib/solid_queue/processes/interruptible.rb
@@ -21,7 +21,7 @@ module SolidQueue::Processes
         if time > 0 && self_pipe[:reader].wait_readable(time)
           loop { self_pipe[:reader].read_nonblock(SELF_PIPE_BLOCK_SIZE) }
         end
-      rescue Errno::EAGAIN, Errno::EINTR
+      rescue Errno::EAGAIN, Errno::EINTR, IO::EWOULDBLOCKWaitReadable
       end
 
       # Self-pipe for signal-handling (http://cr.yp.to/docs/selfpipe.html)


### PR DESCRIPTION
This is to fix #570. 

It looks like this only effects windows. My testing shows the first read works, and the second read throws EWOULDBLOCK. This should pop back up to the poller loop and does another interruptible_sleep, which recreates

This probably isn't great, but it's better than the alternative, which is solid_queue doesn't work on windows at all.