### PR TITLE
Log Supervisor validation errors

### DIFF
--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -140,6 +140,12 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
     info formatted_event(event, action: "Supervisor terminated immediately", **event.payload.slice(:process_id, :supervisor_pid, :supervised_processes))
   end
 
+  def supervisor_initialisation(event)
+    if event.payload.slice(:exception).any?
+      error formatted_event(event, action: "Supervisor failed to initialise", **event.payload.slice(:exception))
+    end
+  end
+
   def unhandled_signal_error(event)
     error formatted_event(event, action: "Received unhandled signal", **event.payload.slice(:signal))
   end

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -12,10 +12,12 @@ module SolidQueue
         SolidQueue.supervisor = true
         configuration = Configuration.new(**options)
 
-        if configuration.valid?
-          new(configuration).tap(&:start)
-        else
-          abort configuration.errors.full_messages.join("\n") + "\nExiting..."
+        SolidQueue.instrument(:supervisor_initialisation, process: self) do
+          if configuration.valid?
+            new(configuration).tap(&:start)
+          else
+            abort configuration.errors.full_messages.join("\n") + "\nExiting..."
+          end
         end
       end
     end


### PR DESCRIPTION
Issue: https://github.com/rails/solid_queue/issues/582

TLDR: Since v1.1.1 SolidQueue silently (kinda) fails on startup. No processes are launched no failure logs are recorded.

If STDOUT is not collected in your logs, startup failure message would be lost. The instrumentation of Supervisor startup begins after the configuration is validated, so logger doesn't have a chance to catch these.

This is a solution that we think might help some teams, it would definitely have helped us. Please feel free to propose a better solution of course!