### PR TITLE
Don't lock thor version to 1.3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       concurrent-ruby (>= 1.3.1)
       fugit (~> 1.11.0)
       railties (>= 7.1)
-      thor (~> 1.3.1)
+      thor (>= 1.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -87,13 +87,14 @@ GEM
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mini_portile2 (2.8.8)
     minitest (5.25.4)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
     mysql2 (0.5.6)
     nio4r (2.7.4)
+    nokogiri (1.18.0-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.0-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.0-x86_64-darwin)
@@ -172,8 +173,10 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
-    sqlite3 (1.5.4)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.7.3-aarch64-linux-gnu)
+    sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86_64-darwin)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
@@ -185,6 +188,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", rails_version
   spec.add_dependency "concurrent-ruby", ">= 1.3.1"
   spec.add_dependency "fugit", "~> 1.11.0"
-  spec.add_dependency "thor", "~> 1.3.1"
+  spec.add_dependency "thor", ">= 1.3.1"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "debug", "~> 1.9"


### PR DESCRIPTION
This is blocking me to upgrade Rails to use thor 1.4.0.

None of the Rails dependencies have upper bounds on any gem to avoid this kind of issues.