### PR TITLE
Set `successfully_enqueued` in `Job.enqueue`

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -30,6 +30,7 @@ module SolidQueue
 
         create_from_active_job(active_job).tap do |enqueued_job|
           active_job.provider_job_id = enqueued_job.id if enqueued_job.persisted?
+          active_job.successfully_enqueued = enqueued_job.persisted?
         end
       end
 

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -130,7 +130,6 @@ module SolidQueue
             active_job.run_callbacks(:enqueue) do
               Job.enqueue(active_job)
             end
-            active_job.successfully_enqueued = true
           end
         end
       end


### PR DESCRIPTION
*(Even though this will be overwritten by Active Job when called through `perform_later`.)

This is necessary for recurring tasks, where we run the `enqueue` callbacks manually and call `Job.enqueue`. We rely on `successfully_enqueued?` to know whether we need to record the recurring execution. We were setting that no matter what after calling `Job.enqueue` because we were relying on that to raise (which would be the case for Active Record errors).

In the case of discarding it because of concurrency controls, the job is simply not persisted but no error is raised, which means we were trying to record a recurring execution without a persisted job, which would raise.

Fixes #598