### PR TITLE
Supress expected warning for test suite

### DIFF
--- a/test/dummy/app/jobs/infinite_recursion_job.rb
+++ b/test/dummy/app/jobs/infinite_recursion_job.rb
@@ -3,8 +3,8 @@ class InfiniteRecursionJob < ApplicationJob
 
   def perform
     start
-  rescue SystemStackError
-    raise ExpectedTestError, "stack level too deep"
+  rescue SystemStackError => e
+    raise ExpectedTestError, "stack level too deep", e.backtrace
   end
 
   private

--- a/test/dummy/app/jobs/infinite_recursion_job.rb
+++ b/test/dummy/app/jobs/infinite_recursion_job.rb
@@ -3,6 +3,8 @@ class InfiniteRecursionJob < ApplicationJob
 
   def perform
     start
+  rescue SystemStackError
+    raise ExpectedTestError, "stack level too deep"
   end
 
   private

--- a/test/models/solid_queue/failed_execution_test.rb
+++ b/test/models/solid_queue/failed_execution_test.rb
@@ -15,13 +15,12 @@ class SolidQueue::FailedExecutionTest < ActiveSupport::TestCase
   end
 
   test "run job that fails with a SystemStackError (stack level too deep)" do
-    silence_on_thread_error_for(SystemStackError) do
-      InfiniteRecursionJob.perform_later
-      @worker.start
+    InfiniteRecursionJob.perform_later
+    @worker.start
 
-      assert_equal 1, SolidQueue::FailedExecution.count
-      assert SolidQueue::Job.last.failed?
-    end
+    assert_equal 1, SolidQueue::FailedExecution.count
+    assert SolidQueue::Job.last.failed?
+    assert_equal "stack level too deep", SolidQueue::FailedExecution.last.message
   end
 
   test "retry failed job" do


### PR DESCRIPTION
I believe we should supress the `ERROR -- stack level too deep: nil` that's currently happening in the test suite:

<img width="1511" height="397" alt="Screenshot 2025-07-22 at 14 40 29" src="https://github.com/user-attachments/assets/86840392-ad55-402e-af72-13adbdc03967" />

The failure is intentional (we're exercising a `SystemStackError` on purpose), but the noisy log isn’t documented and has already confused contributors into thinking it's a real test failure (see #527).