### PR TITLE
Replace deprecated `retries` option for `timeout` in rails 8 and above

### DIFF
--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -11,7 +11,11 @@
 default: &default
   adapter: sqlite3
   pool: 50
-  retries: 100
+  <% if Rails::VERSION::MAJOR >= 8 %>
+  timeout: 5000
+  <% else %>
+  retries: 100 # "retries" is deprecated in rails 8 and will be removed in rails 8.1
+  <% end %>
 
 <% elsif ENV["TARGET_DB"] == "postgres" %>
 default: &default


### PR DESCRIPTION
Just another quick one to clean up the CI logs:

<img width="1505" height="251" alt="Screenshot 2025-07-22 at 19 13 01" src="https://github.com/user-attachments/assets/9f2beb92-9db5-415b-9496-d5ad4c88a3dd" />

`retries` is deprecated in Rails 8.0 and will be fully removed in 8.1, so I replaced `retries: 100` with `timeout: 5000`.

Why 5000? `SQLite3Configuration#configure_connection` sleeps `count * 0.001` seconds on each retry, up to 100:
Σ(1..100) * 0.001 = 0.001 * 5050 ≈ 5.05s → ~5000ms. See:
https://github.com/rails/solid_queue/blob/0ba1b7e77195f2a354360aeb84894111eea02f8e/test/dummy/config/initializers/sqlite3.rb#L13-L22
