### PR TITLE
Fix `SOLID_QUEUE_SKIP_RECURRING` env variable not doing anything

### DIFF
--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -12,7 +12,7 @@ module SolidQueue
       desc: "Path to recurring schedule definition (default: #{Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH}).",
       banner: "SOLID_QUEUE_RECURRING_SCHEDULE"
 
-    class_option :skip_recurring, type: :boolean, default: false,
+    class_option :skip_recurring, type: :boolean,
       desc: "Whether to skip recurring tasks scheduling",
       banner: "SOLID_QUEUE_SKIP_RECURRING"
 


### PR DESCRIPTION
Hello! Thank you for all your work on Solid Queue!

Recently, in v1.2.0, you introduced a support for `SOLID_QUEUE_SKIP_RECURRING` as an alternative to `--skip-recurring`. This is really helpful for us with our Heroku setup, so many thanks!

However, when we upgraded to v1.2.0, we noticed that it doesn't actually skip the recurring jobs. I dug into the code and I think the problem is that without the `--skip-recurring` flag, the `options` that are passed to `SolidQueue::Supervisor.start` already contain `skip_recurring: false`. The default options from `Configuration` don't override this.

To me, the best solution seems to be to remove the `default: false`, since the actual defaults are applied by `Configuration` anyway.

I hope you agree and that this can be included soon! Until then, we're patching this in `bin/jobs`:

```diff
  require_relative "../config/environment"
  require "solid_queue/cli"

+ ARGV << "--skip-recurring" if ENV["SOLID_QUEUE_SKIP_RECURRING"]

  SolidQueue::Cli.start(ARGV)
```