### PR TITLE
Remove Rakefile from gemspec files list

### DIFF
--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/rails/solid_queue"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "UPGRADING.md"]
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "README.md", "UPGRADING.md"]
   end
 
   spec.required_ruby_version = '>= 3.1'


### PR DESCRIPTION
This PR removes `Rakefile` from the list of files included in the gem package. I think that `Rakefile` is only needed for development and testing purposes and does not need to be distributed with the gem.