### PR TITLE
Supress sqlite fork warnings for rails 7.1 & 7.2

### DIFF
--- a/test/dummy/config/initializers/sqlite3.rb
+++ b/test/dummy/config/initializers/sqlite3.rb
@@ -27,4 +27,8 @@ ActiveSupport.on_load :active_record do
     ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend SqliteImmediateTransactions
     ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend SQLite3Configuration
   end
+
+  # Suppress fork safety warnings in the dummy app (used by test suite)
+  # Warnings are safe: https://github.com/rails/solid_queue/issues/506
+  SQLite3::ForkSafety.suppress_warnings! if defined?(SQLite3::ForkSafety)
 end


### PR DESCRIPTION
When sqlite3 > 2.1.0 and rails < 8.0.0 we have the following warning when using Solid Queue:

```
.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/sqlite3-2.5.0-x86_64-linux-gnu/lib/sqlite3/fork_safety.rb:43: warning: Writable sqlite database connection(s) were inherited from a forked process. This is unsafe and the connectio
ns are being closed to prevent possible data corruption. Please close writable sqlite database connections before forking.
```

This is polluting our CI logs and triggering warnings for people using Solid Queue with Rails 7.1 and 7.2 - although the behaviour is safe: https://github.com/rails/solid_queue/issues/324#issuecomment-2372245070

Also mentioned in: https://github.com/rails/solid_queue/issues/506