### PR TITLE
fix: Change MySQL port to 33066

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         ports:
-          - 33060:3306
+          - 33066:3306
         options: --health-cmd "mysql -h localhost -e \"select now()\"" --health-interval 1s --health-timeout 5s --health-retries 30
       postgres:
         image: postgres:15.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - db:/var/lib/mysql
-    ports: [ "127.0.0.1:33060:3306" ]
+    ports: [ "127.0.0.1:33066:3306" ]
   postgres:
     image: postgres:15.1
     environment:

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -33,7 +33,7 @@ default: &default
   username: root
   pool: 20
   host: "127.0.0.1"
-  port: 33060
+  port: 33066
 <% end %>
 
 development:


### PR DESCRIPTION
Resolves: https://github.com/rails/solid_queue/issues/528

In order to avoid conflict with MySQL Protocol X, the port was changed to `33066`.

The change was tested locally by running `docker compose up`