### PR TITLE
Add support for new Puma 7 hook names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     psych (5.2.2)
       date
       stringio
-    puma (6.4.3)
+    puma (7.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -203,7 +203,7 @@ DEPENDENCIES
   mocha
   mysql2
   pg
-  puma
+  puma (~> 7.0)
   rdoc
   rubocop-rails-omakase
   solid_queue!

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "debug", "~> 1.9"
   spec.add_development_dependency "mocha"
-  spec.add_development_dependency "puma"
+  spec.add_development_dependency "puma", "~> 7.0"
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
Puma 7 is no longer compatible with Solid Queue due to the change in hook names (https://github.com/rails/solid_queue/issues/633).

This PR is my attempt to fix it and support both new and old hook names.

Need advice on tests: should I just add Puma 7 to Appraisal, or should it be a matrix that tests all possible combinations of Puma and Rails versions?

Reference: https://github.com/puma/puma/releases/tag/v7.0.0