### PR TITLE
Set `scheduled_at` in `enqueue_all`

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -10,6 +10,7 @@ module SolidQueue
 
     class << self
       def enqueue_all(active_jobs)
+        active_jobs.each { |job| job.scheduled_at ||= Time.current }
         active_jobs_by_job_id = active_jobs.index_by(&:job_id)
 
         transaction do


### PR DESCRIPTION
👋 

We've noticed inconsistent behavior between jobs enqueued normally and those enqueued in batches using `ActiveJob.perform_all_later`. When using batch enqueue, the job attribute `scheduled_at` is missing (unless `wait` or `wait_until` is used).

Besides being inconsistent, this causes a problem with Mission Control, as you can't view the details of a finished job due to this line: https://github.com/rails/mission_control-jobs/blob/7ac38357e33778099b8b76b5476bf36ad3b53bf2/lib/active_job/job_proxy.rb#L30, which throws the following exception:
```
can't convert NilClass into an exact number (TypeError)

      minus_without_duration(other)
```

This PR makes the behavior consistent and adds tests.