### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Solid Queue can be used with SQL databases such as MySQL, PostgreSQL, or SQLite,
 Solid Queue is configured by default in new Rails 8 applications. If you're running an earlier version, you can add it manually following these steps:
 
 1. `bundle add solid_queue`
-2. `bin/rails solid_queue:install`
+2. `bin/rails g solid_queue:install`
 
 (Note: The minimum supported version of Rails is 7.1 and Ruby is 3.1.6.)
 


### PR DESCRIPTION
```bash
bin/rails solid_queue:install

Unrecognized command "solid_queue:install" (Rails::Command::UnrecognizedCommandError)
Did you mean?  solid_queue:start
```

As opposed to:

```bash
bin/rails g solid_queue:install

        gsub  config/environments/production.rb
      create  config/solid_queue.yml
       rails  railties:install:migrations FROM=solid_queue
Copied migration 20250912213359_create_solid_queue_tables.solid_queue.rb from solid_queue
Copied migration 20250912213360_add_missing_index_to_blocked_executions.solid_queue.rb from solid_queue
Copied migration 20250912213361_create_recurring_executions.solid_queue.rb from solid_queue
Clearing idea diffs…
Idea diffs cleared.
```