### PR TITLE
Re-institute async mode

### DIFF
--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -13,7 +13,7 @@ Puma::Plugin.create do
 
   def start(launcher)
     @log_writer = launcher.log_writer
-    @puma_pid = $
+    @puma_pid = $$
 
     if launcher.options[:solid_queue_mode] == :async
       start_async(launcher)

--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -83,7 +83,7 @@ Puma::Plugin.create do
       loop do
         if send(process_dead)
           log message
-          Process.kill(:INT, $)
+          Process.kill(:INT, $$)
           break
         end
         sleep 2

--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -1,40 +1,68 @@
 require "puma/plugin"
 
+module Puma
+  class DSL
+    def solid_queue_mode(mode = :fork)
+      @options[:solid_queue_mode] = mode.to_sym
+    end
+  end
+end
+
 Puma::Plugin.create do
   attr_reader :puma_pid, :solid_queue_pid, :log_writer, :solid_queue_supervisor
 
   def start(launcher)
     @log_writer = launcher.log_writer
-    @puma_pid = $$
+    @puma_pid = $
 
-    in_background do
-      monitor_solid_queue
-    end
-
-    if Gem::Version.new(Puma::Const::VERSION) < Gem::Version.new("7")
-      launcher.events.on_booted do
-        @solid_queue_pid = fork do
-          Thread.new { monitor_puma }
-          SolidQueue::Supervisor.start
-        end
-      end
-
-      launcher.events.on_stopped { stop_solid_queue }
-      launcher.events.on_restart { stop_solid_queue }
+    if launcher.options[:solid_queue_mode] == :async
+      start_async(launcher)
     else
-      launcher.events.after_booted do
-        @solid_queue_pid = fork do
-          Thread.new { monitor_puma }
-          SolidQueue::Supervisor.start
-        end
-      end
-
-      launcher.events.after_stopped { stop_solid_queue }
-      launcher.events.before_restart { stop_solid_queue }
+      start_forked(launcher)
     end
   end
 
   private
+    def start_forked(launcher)
+      in_background do
+        monitor_solid_queue
+      end
+
+      if Gem::Version.new(Puma::Const::VERSION) < Gem::Version.new("7")
+        launcher.events.on_booted do
+          @solid_queue_pid = fork do
+            Thread.new { monitor_puma }
+            SolidQueue::Supervisor.start(mode: :fork)
+          end
+        end
+
+        launcher.events.on_stopped { stop_solid_queue }
+        launcher.events.on_restart { stop_solid_queue }
+      else
+        launcher.events.after_booted do
+          @solid_queue_pid = fork do
+            Thread.new { monitor_puma }
+            SolidQueue::Supervisor.start(mode: :fork)
+          end
+        end
+
+        launcher.events.after_stopped { stop_solid_queue }
+        launcher.events.before_restart { stop_solid_queue }
+      end
+    end
+
+    def start_async(launcher)
+      if Gem::Version.new(Puma::Const::VERSION) < Gem::Version.new("7")
+        launcher.events.on_booted { @solid_queue_supervisor = SolidQueue::Supervisor.start(mode: :async) }
+        launcher.events.on_stopped { solid_queue_supervisor&.stop }
+        launcher.events.on_restart { solid_queue_supervisor&.stop; @solid_queue_supervisor = SolidQueue::Supervisor.start(mode: :async) }
+      else
+        launcher.events.after_booted { @solid_queue_supervisor = SolidQueue::Supervisor.start(mode: :async) }
+        launcher.events.after_stopped { solid_queue_supervisor&.stop }
+        launcher.events.before_restart { solid_queue_supervisor&.stop; @solid_queue_supervisor = SolidQueue::Supervisor.start(mode: :async) }
+      end
+    end
+
     def stop_solid_queue
       Process.waitpid(solid_queue_pid, Process::WNOHANG)
       log "Stopping Solid Queue..."
@@ -55,7 +83,7 @@ Puma::Plugin.create do
       loop do
         if send(process_dead)
           log message
-          Process.kill(:INT, $$)
+          Process.kill(:INT, $)
           break
         end
         sleep 2

--- a/lib/solid_queue/async_supervisor.rb
+++ b/lib/solid_queue/async_supervisor.rb
@@ -17,7 +17,14 @@ module SolidQueue
           instance.mode = :async
         end
 
-        thread = Thread.new { process_instance.start }
+        thread = Thread.new do
+          begin
+            process_instance.start
+          rescue Exception => e
+            puts "Error in thread: #{e.message}"
+            puts e.backtrace
+          end
+        end
         threads[thread] = [ process_instance, configured_process ]
       end
 

--- a/lib/solid_queue/async_supervisor.rb
+++ b/lib/solid_queue/async_supervisor.rb
@@ -110,11 +110,16 @@ module SolidQueue
       end
 
       def check_and_replace_terminated_threads
+        terminated_threads = {}
         threads.each do |thread, (process, configured_process)|
           unless thread.alive?
-            threads.delete(thread)
-            start_process(configured_process)
+            terminated_threads[thread] = configured_process
           end
+        end
+
+        terminated_threads.each do |thread, configured_process|
+          threads.delete(thread)
+          start_process(configured_process)
         end
       end
 

--- a/lib/solid_queue/async_supervisor.rb
+++ b/lib/solid_queue/async_supervisor.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module SolidQueue
+  class AsyncSupervisor < Supervisor
+    private
+      attr_reader :threads
+
+      def start_processes
+        @threads = {}
+
+        configuration.configured_processes.each { |configured_process| start_process(configured_process) }
+      end
+
+      def start_process(configured_process)
+        process_instance = configured_process.instantiate.tap do |instance|
+          instance.supervised_by process
+          instance.mode = :async
+        end
+
+        thread = Thread.new { process_instance.start }
+        threads[thread] = configured_process
+      end
+
+      def terminate_gracefully
+        SolidQueue.instrument(:graceful_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do |payload|
+          processes.each(&:stop)
+
+          Timer.wait_until(SolidQueue.shutdown_timeout, -> { all_threads_terminated? }) do
+            # No-op, we just wait
+          end
+
+          unless all_threads_terminated?
+            payload[:shutdown_timeout_exceeded] = true
+            terminate_immediately
+          end
+        end
+      end
+
+      def terminate_immediately
+        SolidQueue.instrument(:immediate_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do
+          threads.keys.each(&:kill)
+        end
+      end
+
+      attr_reader :threads
+
+      def start_processes
+        @threads = {}
+
+        configuration.configured_processes.each { |configured_process| start_process(configured_process) }
+      end
+
+      def start_process(configured_process)
+        process_instance = configured_process.instantiate.tap do |instance|
+          instance.supervised_by process
+          instance.mode = :async
+        end
+
+        thread = Thread.new { process_instance.start }
+        threads[thread] = [ process_instance, configured_process ]
+      end
+
+      def terminate_gracefully
+        SolidQueue.instrument(:graceful_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do |payload|
+          processes.each(&:stop)
+
+          Timer.wait_until(SolidQueue.shutdown_timeout, -> { all_threads_terminated? }) do
+            # No-op, we just wait
+          end
+
+          unless all_threads_terminated?
+            payload[:shutdown_timeout_exceeded] = true
+            terminate_immediately
+          end
+        end
+      end
+
+      def terminate_immediately
+        SolidQueue.instrument(:immediate_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do
+          threads.keys.each(&:kill)
+        end
+      end
+
+      def supervised_processes
+        processes.map(&:to_s)
+      end
+
+      def reap_and_replace_terminated_forks
+        # No-op in async mode, we'll check for dead threads in the supervise loop
+      end
+
+      def all_threads_terminated?
+        threads.keys.all? { |thread| !thread.alive? }
+      end
+
+      def supervise
+        loop do
+          break if stopped?
+
+          set_procline
+          process_signal_queue
+
+          unless stopped?
+            check_and_replace_terminated_threads
+            interruptible_sleep(1.second)
+          end
+        end
+      ensure
+        shutdown
+      end
+
+      def check_and_replace_terminated_threads
+        threads.each do |thread, (process, configured_process)|
+          unless thread.alive?
+            threads.delete(thread)
+            start_process(configured_process)
+          end
+        end
+      end
+
+      def processes
+        threads.values.map(&:first)
+      end
+  end
+end

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -8,6 +8,8 @@ module SolidQueue
       desc: "Path to config file (default: #{Configuration::DEFAULT_CONFIG_FILE_PATH}).",
       banner: "SOLID_QUEUE_CONFIG"
 
+    class_option :mode, type: :string, default: "fork", enum: %w[ fork async ], desc: "Whether to fork processes for workers and dispatchers (fork) or to run these in the same process as the supervisor (async)"
+
     class_option :recurring_schedule_file, type: :string,
       desc: "Path to recurring schedule definition (default: #{Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH}).",
       banner: "SOLID_QUEUE_RECURRING_SCHEDULE"

--- a/lib/solid_queue/fork_supervisor.rb
+++ b/lib/solid_queue/fork_supervisor.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module SolidQueue
+  class ForkSupervisor < Supervisor
+    private
+      attr_reader :forks, :configured_processes
+
+      def start_processes
+        @forks = {}
+        @configured_processes = {}
+
+        configuration.configured_processes.each { |configured_process| start_process(configured_process) }
+      end
+
+      def start_process(configured_process)
+        process_instance = configured_process.instantiate.tap do |instance|
+          instance.supervised_by process
+          instance.mode = :fork
+        end
+
+        pid = fork do
+          process_instance.start
+        end
+
+        configured_processes[pid] = configured_process
+        forks[pid] = process_instance
+      end
+
+      def terminate_gracefully
+        SolidQueue.instrument(:graceful_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do |payload|
+          term_forks
+
+          Timer.wait_until(SolidQueue.shutdown_timeout, -> { all_forks_terminated? }) do
+            reap_terminated_forks
+          end
+
+          unless all_forks_terminated?
+            payload[:shutdown_timeout_exceeded] = true
+            terminate_immediately
+          end
+        end
+      end
+
+      def terminate_immediately
+        SolidQueue.instrument(:immediate_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do
+          quit_forks
+        end
+      end
+
+      def supervised_processes
+        forks.keys
+      end
+
+      def term_forks
+        signal_processes(forks.keys, :TERM)
+      end
+
+      def quit_forks
+        signal_processes(forks.keys, :QUIT)
+      end
+
+      def reap_and_replace_terminated_forks
+        loop do
+          pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
+          break unless pid
+
+          replace_fork(pid, status)
+        end
+      end
+
+      def reap_terminated_forks
+        loop do
+          pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
+          break unless pid
+
+          if (terminated_fork = forks.delete(pid)) && (!status.exited? || status.exitstatus > 0)
+            handle_claimed_jobs_by(terminated_fork, status)
+          end
+
+          configured_processes.delete(pid)
+        end
+      rescue SystemCallError
+        # All children already reaped
+      end
+
+      def replace_fork(pid, status)
+        SolidQueue.instrument(:replace_fork, supervisor_pid: ::Process.pid, pid: pid, status: status) do |payload|
+          if terminated_fork = forks.delete(pid)
+            payload[:fork] = terminated_fork
+            handle_claimed_jobs_by(terminated_fork, status)
+
+            start_process(configured_processes.delete(pid))
+          end
+        end
+      end
+
+      # When a supervised fork crashes or exits we need to mark all the
+      # executions it had claimed as failed so that they can be retried
+      # by some other worker.
+      def handle_claimed_jobs_by(terminated_fork, status)
+        if registered_process = SolidQueue::Process.find_by(name: terminated_fork.name)
+          error = Processes::ProcessExitError.new(status)
+          registered_process.fail_all_claimed_executions_with(error)
+        end
+      end
+
+      def all_forks_terminated?
+        forks.empty?
+      end
+  end
+end

--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -9,11 +9,7 @@ module SolidQueue::Processes
     def start
       boot
 
-      if running_async?
-        @thread = create_thread { run }
-      else
-        run
-      end
+      run
     end
 
     def stop

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "solid_queue/fork_supervisor"
-require "solid_queue/async_supervisor"
-
 module SolidQueue
   class Supervisor < Processes::Base
     include LifecycleHooks

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "solid_queue/fork_supervisor"
+require "solid_queue/async_supervisor"
+
 module SolidQueue
   class Supervisor < Processes::Base
     include LifecycleHooks
@@ -13,7 +16,8 @@ module SolidQueue
         configuration = Configuration.new(**options)
 
         if configuration.valid?
-          new(configuration).tap(&:start)
+          klass = configuration.mode.fork? ? ForkSupervisor : AsyncSupervisor
+          klass.new(configuration).tap(&:start)
         else
           abort configuration.errors.full_messages.join("\n") + "\nExiting..."
         end
@@ -22,9 +26,6 @@ module SolidQueue
 
     def initialize(configuration)
       @configuration = configuration
-      @forks = {}
-      @configured_processes = {}
-
       super
     end
 
@@ -44,7 +45,7 @@ module SolidQueue
     end
 
     private
-      attr_reader :configuration, :forks, :configured_processes
+      attr_reader :configuration
 
       def boot
         SolidQueue.instrument(:start_process, process: self) do
@@ -52,10 +53,6 @@ module SolidQueue
             sync_std_streams
           end
         end
-      end
-
-      def start_processes
-        configuration.configured_processes.each { |configured_process| start_process(configured_process) }
       end
 
       def supervise
@@ -74,43 +71,12 @@ module SolidQueue
         shutdown
       end
 
-      def start_process(configured_process)
-        process_instance = configured_process.instantiate.tap do |instance|
-          instance.supervised_by process
-          instance.mode = :fork
-        end
-
-        pid = fork do
-          process_instance.start
-        end
-
-        configured_processes[pid] = configured_process
-        forks[pid] = process_instance
+      def start_processes
+        raise NotImplementedError
       end
 
       def set_procline
         procline "supervising #{supervised_processes.join(", ")}"
-      end
-
-      def terminate_gracefully
-        SolidQueue.instrument(:graceful_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do |payload|
-          term_forks
-
-          Timer.wait_until(SolidQueue.shutdown_timeout, -> { all_forks_terminated? }) do
-            reap_terminated_forks
-          end
-
-          unless all_forks_terminated?
-            payload[:shutdown_timeout_exceeded] = true
-            terminate_immediately
-          end
-        end
-      end
-
-      def terminate_immediately
-        SolidQueue.instrument(:immediate_termination, process_id: process_id, supervisor_pid: ::Process.pid, supervised_processes: supervised_processes) do
-          quit_forks
-        end
       end
 
       def shutdown
@@ -125,65 +91,8 @@ module SolidQueue
         STDOUT.sync = STDERR.sync = true
       end
 
-      def supervised_processes
-        forks.keys
-      end
-
-      def term_forks
-        signal_processes(forks.keys, :TERM)
-      end
-
-      def quit_forks
-        signal_processes(forks.keys, :QUIT)
-      end
-
       def reap_and_replace_terminated_forks
-        loop do
-          pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
-          break unless pid
-
-          replace_fork(pid, status)
-        end
-      end
-
-      def reap_terminated_forks
-        loop do
-          pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
-          break unless pid
-
-          if (terminated_fork = forks.delete(pid)) && (!status.exited? || status.exitstatus > 0)
-            handle_claimed_jobs_by(terminated_fork, status)
-          end
-
-          configured_processes.delete(pid)
-        end
-      rescue SystemCallError
-        # All children already reaped
-      end
-
-      def replace_fork(pid, status)
-        SolidQueue.instrument(:replace_fork, supervisor_pid: ::Process.pid, pid: pid, status: status) do |payload|
-          if terminated_fork = forks.delete(pid)
-            payload[:fork] = terminated_fork
-            handle_claimed_jobs_by(terminated_fork, status)
-
-            start_process(configured_processes.delete(pid))
-          end
-        end
-      end
-
-      # When a supervised fork crashes or exits we need to mark all the
-      # executions it had claimed as failed so that they can be retried
-      # by some other worker.
-      def handle_claimed_jobs_by(terminated_fork, status)
-        if registered_process = SolidQueue::Process.find_by(name: terminated_fork.name)
-          error = Processes::ProcessExitError.new(status)
-          registered_process.fail_all_claimed_executions_with(error)
-        end
-      end
-
-      def all_forks_terminated?
-        forks.empty?
+        # No-op by default, implemented in ForkSupervisor
       end
   end
 end


### PR DESCRIPTION
This is less of a "this is ready to be merged", and more of an effort to reinvigorate conversation around this feature. I cobbled this together as a proof of concept because I simply couldn't use the multi-process approach on the server I'm trying to deploy to. This is related to #343, and tries to naively reimplement [this](https://github.com/rails/solid_queue/pull/308/commits/4b3483a9f85c408bba509b179c6ebccd5978e4c9#diff-8c7602bda2cec1fb5ceb4ca70a520e9ac132949316809cdac7c22a61ea164a61)

I originally stumbled on this feature because I was testing Kamal on a 1GB VPS. The initial deploy would work, however there wasn't enough resource headroom for the second deploy. I narrowed this down to SQ using ~100MB per process, essentially taking up half the available memory on the system. 

<img width="1368" height="117" alt="image" src="https://github.com/user-attachments/assets/e6d65132-8758-401a-bc32-be0419bcb596" />

After implementing this change, I saw the application memory drop from ~700MB to ~270MB.

<img width="822" height="45" alt="image" src="https://github.com/user-attachments/assets/43aa81ed-7c54-4671-a401-403cee0c8a52" />

The usage is simply placing this in puma.rb

```ruby
if ENV["SOLID_QUEUE_IN_PUMA"]
  plugin :solid_queue
  solid_queue_mode :async
end
```

I currently have this deployed to a 1GB droplet - the application is running quickly, background jobs are running, and redeploys are succeeding

