### PR TITLE
Replace use of `ActiveRecord::Base.connection` with `with_connection`

### DIFF
--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -58,8 +58,11 @@ module SolidQueue
       end
 
       def determine_backtrace_size_limit
-        column = self.class.connection.schema_cache.columns_hash(self.class.table_name)["error"]
-        if column.limit.present?
+        column = self.class.connection_pool.with_connection do |connection|
+          connection.schema_cache.columns_hash(self.class.table_name)["error"]
+        end
+
+        if column && column.limit.present?
           column.limit - exception_class_name.bytesize - exception_message.bytesize - JSON_OVERHEAD
         end
       end

--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -6,11 +6,19 @@ module SolidQueue
 
     connects_to(**SolidQueue.connects_to) if SolidQueue.connects_to
 
-    def self.non_blocking_lock
-      if SolidQueue.use_skip_locked
-        lock(Arel.sql("FOR UPDATE SKIP LOCKED"))
-      else
-        lock
+    class << self
+      def non_blocking_lock
+        if SolidQueue.use_skip_locked
+          lock(Arel.sql("FOR UPDATE SKIP LOCKED"))
+        else
+          lock
+        end
+      end
+
+      def supports_insert_conflict_target?
+        connection_pool.with_connection do |connection|
+          connection.supports_insert_conflict_target?
+        end
       end
     end
   end

--- a/app/models/solid_queue/recurring_execution.rb
+++ b/app/models/solid_queue/recurring_execution.rb
@@ -8,7 +8,7 @@ module SolidQueue
 
     class << self
       def create_or_insert!(**attributes)
-        if connection.supports_insert_conflict_target?
+        if supports_insert_conflict_target?
           # PostgreSQL fails and aborts the current transaction when it hits a duplicate key conflict
           # during two concurrent INSERTs for the same value of an unique index. We need to explicitly
           # indicate unique_by to ignore duplicate rows by this value when inserting

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -36,7 +36,7 @@ module SolidQueue
       end
 
       def create_or_update_all(tasks)
-        if connection.supports_insert_conflict_target?
+        if supports_insert_conflict_target?
           # PostgreSQL fails and aborts the current transaction when it hits a duplicate key conflict
           # during two concurrent INSERTs for the same value of an unique index. We need to explicitly
           # indicate unique_by to ignore duplicate rows by this value when inserting

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -20,7 +20,7 @@ module SolidQueue
 
       # Requires a unique index on key
       def create_unique_by(attributes)
-        if connection.supports_insert_conflict_target?
+        if supports_insert_conflict_target?
           insert({ **attributes }, unique_by: :key).any?
         else
           create!(**attributes)


### PR DESCRIPTION
So that when running with `permanent_connection_checkout` set to `false`, this doesn't cause any problems. Using `connection` is deprecated in any case, so this was needed regardless.

Fixes #646