### PR TITLE
Change default polling_interval to 1 sec

### DIFF
--- a/lib/generators/solid_queue/install/templates/config/queue.yml
+++ b/lib/generators/solid_queue/install/templates/config/queue.yml
@@ -6,7 +6,7 @@ default: &default
     - queues: "*"
       threads: 3
       processes: <%%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
 
 development:
   <<: *default


### PR DESCRIPTION
I think the current `polling_interval: 0.1` for queue.yml is too aggressive so I'm sending the following PR to make the default less aggressive:

```diff
# lib/generators/solid_queue/install/templates/config/queue.yml
     - queues: "*"
       threads: 3
       processes: <%%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
```

Actually I encountered several race-conditions with the `polling_interval: 0.1`  when querying the DB (SQLite3) from my dashboard in fly.io.

Hope this change would be helpful for future users 🙏