### PR TITLE
Wait for polling queries in logging tests instead of sleeping

### DIFF
--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -110,7 +110,9 @@ class DispatcherTest < ActiveSupport::TestCase
     assert_equal 3, SolidQueue::ScheduledExecution.count
 
     dispatcher.start
-    wait_while_with_timeout(1.second) { SolidQueue::ScheduledExecution.any? }
+    # Give the dispatcher thread enough margin to boot and run its first polls
+    # on a slow runner; the wait returns as soon as everything is dispatched.
+    wait_while_with_timeout(5.seconds) { SolidQueue::ScheduledExecution.any? }
 
     skip_active_record_query_cache do
       assert_equal 0, SolidQueue::ScheduledExecution.count

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -38,15 +38,17 @@ class DispatcherTest < ActiveSupport::TestCase
 
   test "polling queries are logged" do
     log = StringIO.new
+    polling_query = /SELECT .* FROM .solid_queue_scheduled_executions. WHERE/
+
     with_active_record_logger(ActiveSupport::Logger.new(log)) do
       with_polling(silence: false) do
         rewind_io(log)
         @dispatcher.start
-        sleep 0.5.second
+        wait_while_with_timeout(3.seconds) { !log.string.match?(polling_query) }
       end
     end
 
-    assert_match /SELECT .* FROM .solid_queue_scheduled_executions. WHERE/, log.string
+    assert_match polling_query, log.string
   end
 
   test "polling queries can be silenced" do

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -146,14 +146,16 @@ class WorkerTest < ActiveSupport::TestCase
 
   test "polling queries are logged" do
     log = StringIO.new
+    polling_query = /SELECT .* FROM .solid_queue_ready_executions. WHERE .solid_queue_ready_executions...queue_name./
+
     with_active_record_logger(ActiveSupport::Logger.new(log)) do
       with_polling(silence: false) do
         @worker.start
-        sleep 0.2
+        wait_while_with_timeout(3.seconds) { !log.string.match?(polling_query) }
       end
     end
 
-    assert_match /SELECT .* FROM .solid_queue_ready_executions. WHERE .solid_queue_ready_executions...queue_name./, log.string
+    assert_match polling_query, log.string
   end
 
   test "polling queries can be silenced" do


### PR DESCRIPTION
Related to #602

### Problem

The "polling queries are logged" tests in `WorkerTest` and `DispatcherTest` start a worker/dispatcher and sleep for a fixed window (0.2s / 0.5s) before asserting that the polling `SELECT` shows up in the captured log. On a slow CI runner, process boot (DB registration, pool startup) can eat the whole window before the first poll executes, so the log only contains the process `INSERT` and the assertion fails.

Example failure from a recent CI run (MySQL job):

```
Failure:
WorkerTest#test_polling_queries_are_logged [test/unit/worker_test.rb:156]:
Expected /SELECT .* FROM .solid_queue_ready_executions. .../ to match
"  TRANSACTION (0.2ms)  BEGIN\n  SolidQueue::Process Create (0.5ms)  INSERT INTO `solid_queue_processes` ..."
```

### Fix

Poll the captured log for the expected query with `wait_while_with_timeout` (3 seconds) instead of a flat sleep. The tests remain as fast as before in the common case — the wait returns as soon as the query appears — and become robust when the runner is slow. On timeout, the existing assertion still runs and reports the log contents.
