### PR TITLE
Keep semaphore slots held while blocked jobs are enqueued in concurrency test

### DIFF
--- a/test/integration/concurrency_controls_test.rb
+++ b/test/integration/concurrency_controls_test.rb
@@ -75,10 +75,13 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
     # and B finish quickly, freeing slots that drain D–H; C reads the empty
     # status and pauses far longer than everyone else, so it saves last and its
     # write (built on the empty status) overwrites all the others, leaving "C".
+    # A and B must pause long enough to still hold their semaphore slots while
+    # D–H are being enqueued, even on a slow CI runner — otherwise some of D–H
+    # claim a freed slot instead of blocking.
     assert_no_difference -> { SolidQueue::BlockedExecution.count } do
-      ThrottledUpdateResultJob.perform_later(@result, name: "A", pause: 0.5.seconds)
-      ThrottledUpdateResultJob.perform_later(@result, name: "B", pause: 0.5.seconds)
-      ThrottledUpdateResultJob.perform_later(@result, name: "C", pause: 3.seconds)
+      ThrottledUpdateResultJob.perform_later(@result, name: "A", pause: 1.5.seconds)
+      ThrottledUpdateResultJob.perform_later(@result, name: "B", pause: 1.5.seconds)
+      ThrottledUpdateResultJob.perform_later(@result, name: "C", pause: 4.seconds)
     end
 
     wait_for(timeout: 2.seconds) { SolidQueue::ClaimedExecution.count >= 3 }


### PR DESCRIPTION
Related to #602

### Problem

`ConcurrencyControlsTest#test_run_several_jobs_over_the_same_record_limiting_concurrency` is one of the most frequent CI flakes at the moment — it failed standalone on recent `main` runs (e.g. the run for 7f59932) and on unrelated PR runs, always on the same assertion:

```
Expected: 5
  Actual: 4  # BlockedExecution difference
```

The test claims all three semaphore slots with jobs A, B and C, waits until the three are claimed, then enqueues D–H expecting all five to become `BlockedExecution`. A and B only pause for 0.5s — and that clock starts as soon as they're claimed, before the wait even returns. On a slow runner, by the time the five D–H `perform_later` inserts complete, A or B has already finished and released a semaphore slot, so one of D–H claims it instead of blocking, and the `+5` assertion comes up short.

### Fix

Give A and B enough pause (1.5s) to still be holding their slots while D–H are being enqueued, and bump C (3s → 4s) so it keeps finishing well after everything else, preserving the test's final `["C"]` assertion. The constraint is now also documented in the test comment.

Adds ~1s to the test's runtime in exchange for tripling the margin on the race window.

### Testing

Ran the test 6 consecutive times on MySQL plus the full `concurrency_controls_test.rb` file — all green.
