### PR TITLE
Stop processes whose heartbeats keep failing past the alive threshold

### DIFF
--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -21,10 +21,14 @@ class SolidQueue::Process < SolidQueue::Record
 
   def heartbeat
     # Clear any previous changes before locking, for example, in case a previous heartbeat
-    # failed because of a DB issue (with SQLite depending on configuration, a BusyException
-    # is not rare) and we still have the unpersisted value
+    # failed because of a DB issue and we still have the unpersisted value
     restore_attributes
     with_lock { touch(:last_heartbeat_at) }
+  rescue
+    # touch writes the attribute before persisting; don't let a failed
+    # update leave this object claiming a heartbeat that was never persisted
+    restore_attributes
+    raise
   end
 
   def deregister(pruned: false)

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -55,28 +55,29 @@ module SolidQueue::Processes
 
       def heartbeat
         process&.heartbeat
-        @heartbeats_failing_since = nil
       rescue ActiveRecord::RecordNotFound
-        self.process = nil
-        wake_up
+        # Our registration is gone: a supervisor pruned it
+        stop_to_be_replaced
       rescue => error
-        # Errors other than a missing registration (e.g. the DB connection dropping)
-        # can prevent the heartbeat from going through, and even from finding out
-        # whether the registration is still there. If this persists past the alive
-        # threshold, other processes will have considered this one dead and pruned
-        # its registration, so stop and let the supervisor replace it with a process
-        # that can register afresh, rather than running unregistered indefinitely.
-        @heartbeats_failing_since ||= Time.current
-        if heartbeats_failing_for_too_long?
-          self.process = nil
-          wake_up
-        end
-
+        # Errors like a dropped database connection prevent the
+        # heartbeat from going through, and even from finding out whether the
+        # registration is still there
+        stop_to_be_replaced if presumed_dead?
         raise error
       end
 
-      def heartbeats_failing_for_too_long?
-        @heartbeats_failing_since && Time.current - @heartbeats_failing_since > SolidQueue.process_alive_threshold
+      # Whether this process's registration is prunable: if the last heartbeat that
+      # we were able to persist is older than the alive threshold, supervisors
+      # consider this one dead and would have pruned its registration by now
+      def presumed_dead?
+        process && process.last_heartbeat_at <= SolidQueue.process_alive_threshold.ago
+      end
+
+      # Deregister locally and wake the run loop, which stops when
+      # unregistered, so the supervisor replaces this process
+      def stop_to_be_replaced
+        self.process = nil
+        wake_up
       end
 
       def reload_metadata

--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -55,9 +55,28 @@ module SolidQueue::Processes
 
       def heartbeat
         process&.heartbeat
+        @heartbeats_failing_since = nil
       rescue ActiveRecord::RecordNotFound
         self.process = nil
         wake_up
+      rescue => error
+        # Errors other than a missing registration (e.g. the DB connection dropping)
+        # can prevent the heartbeat from going through, and even from finding out
+        # whether the registration is still there. If this persists past the alive
+        # threshold, other processes will have considered this one dead and pruned
+        # its registration, so stop and let the supervisor replace it with a process
+        # that can register afresh, rather than running unregistered indefinitely.
+        @heartbeats_failing_since ||= Time.current
+        if heartbeats_failing_for_too_long?
+          self.process = nil
+          wake_up
+        end
+
+        raise error
+      end
+
+      def heartbeats_failing_for_too_long?
+        @heartbeats_failing_since && Time.current - @heartbeats_failing_since > SolidQueue.process_alive_threshold
       end
 
       def reload_metadata

--- a/test/models/solid_queue/process_test.rb
+++ b/test/models/solid_queue/process_test.rb
@@ -80,4 +80,17 @@ class SolidQueue::ProcessTest < ActiveSupport::TestCase
       process.heartbeat
     end
   end
+
+  test "a heartbeat that fails to persist doesn't leave a fresh in-memory timestamp" do
+    process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-42")
+    persisted_heartbeat_at = process.last_heartbeat_at
+
+    process.stubs(:_update_row).raises(ActiveRecord::StatementInvalid.new("no connection"))
+
+    travel 1.minute do
+      assert_raises(ActiveRecord::StatementInvalid) { process.heartbeat }
+    end
+
+    assert_equal persisted_heartbeat_at, process.last_heartbeat_at
+  end
 end

--- a/test/unit/process_recovery_test.rb
+++ b/test/unit/process_recovery_test.rb
@@ -15,6 +15,36 @@ class ProcessRecoveryTest < ActiveSupport::TestCase
     JobResult.delete_all
   end
 
+  test "alive scheduler whose registration is pruned is torn down and replaced" do
+    old_heartbeat_interval, SolidQueue.process_heartbeat_interval = SolidQueue.process_heartbeat_interval, 1.second
+
+    @pid = run_supervisor_as_fork(skip_recurring: false)
+    wait_for_registered_processes(5, timeout: 3.seconds) # supervisor + 2 workers + dispatcher + scheduler
+
+    scheduler_process = SolidQueue::Process.find_by(kind: "Scheduler")
+    assert scheduler_process.present?
+
+    # Simulate another process's prune sweep removing the scheduler's registration
+    # while the scheduler itself is still alive
+    scheduler_process.delete
+
+    # The scheduler should notice its registration is gone on its next heartbeat,
+    # terminate, and be replaced by the supervisor with a fresh registration
+    wait_while_with_timeout(10.seconds) do
+      skip_active_record_query_cache do
+        SolidQueue::Process.where(kind: "Scheduler").where.not(id: scheduler_process.id).none?
+      end
+    end
+
+    skip_active_record_query_cache do
+      new_scheduler_process = SolidQueue::Process.where(kind: "Scheduler").last
+      assert new_scheduler_process.present?
+      assert_not_equal scheduler_process.id, new_scheduler_process.id
+    end
+  ensure
+    SolidQueue.process_heartbeat_interval = old_heartbeat_interval
+  end
+
   test "supervisor handles missing process record and fails claimed executions properly" do
     # Start a supervisor with one worker
     @pid = run_supervisor_as_fork(workers: [ { queues: "*", polling_interval: 0.1, processes: 1 } ])

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -215,6 +215,26 @@ class WorkerTest < ActiveSupport::TestCase
     SolidQueue.process_heartbeat_interval = old_heartbeat_interval
   end
 
+  test "terminate when heartbeats have been failing for longer than the alive threshold" do
+    old_heartbeat_interval, SolidQueue.process_heartbeat_interval = SolidQueue.process_heartbeat_interval, 0.2.seconds
+    old_alive_threshold, SolidQueue.process_alive_threshold = SolidQueue.process_alive_threshold, 0.5.seconds
+
+    SolidQueue::Process.any_instance.stubs(:heartbeat).raises(ActiveRecord::StatementInvalid.new("connection lost"))
+
+    @worker.start
+    wait_for_registered_processes(1, timeout: 1.second)
+
+    assert_not @worker.pool.shutdown?
+
+    # Heartbeats keep failing without the registration being confirmed gone, so
+    # the worker should give up once the failures outlast the alive threshold
+    wait_while_with_timeout(3) { !@worker.pool.shutdown? }
+    assert @worker.pool.shutdown?
+  ensure
+    SolidQueue.process_heartbeat_interval = old_heartbeat_interval
+    SolidQueue.process_alive_threshold = old_alive_threshold
+  end
+
   test "sleeps `10.minutes` if at capacity" do
     3.times { |i| StoreResultJob.perform_later(i, pause: 5.seconds) }
 


### PR DESCRIPTION
Related to #763 (and the same family as #751).

### What I found

The core scenario in #763 — a process whose registration gets pruned while it's still alive — already self-heals on `main`: the next heartbeat raises `RecordNotFound`, `Registrable#heartbeat` clears the process and wakes the run loop, `shutting_down?` returns true via `!registered?`, the fork exits, and the supervisor replaces it. I've added a regression test proving this end-to-end for the scheduler (start a supervisor with a scheduler, delete the scheduler's `solid_queue_processes` row while it's running, assert a fresh registration appears).

### The remaining hole

That self-heal only fires when the heartbeat gets a clean `RecordNotFound`. Heartbeats can also fail without confirming anything about the registration — a dropped DB connection after host sleep/resume, SQLite busy errors (the reporter's setup in #763) — and those errors are only reported via the timer task's observer. The process then keeps running unregistered indefinitely: the supervisor never replaces it because it never exits, and from the outside it's a zombie that stops doing visible work. This matches the reported evidence: an alive, supervised scheduler with no `solid_queue_processes` row and no "Replaced terminated Scheduler" ever logged.

### Fix

Track when heartbeats started failing. Once they've been failing for longer than `SolidQueue.process_alive_threshold` — the exact point at which every other process considers this one dead and prunable — treat it like finding the registration gone: clear the process and wake the run loop so the process stops and the supervisor starts a replacement that can register afresh. Errors are still re-raised so the existing observer reporting is unchanged, and a successful heartbeat resets the tracking, so transient blips don't accumulate.

### Testing

- New unit test: a worker whose heartbeats persistently raise `ActiveRecord::StatementInvalid` shuts down its pool once the failures outlast the alive threshold (fails on `main`, passes with this change).
- New regression test for the existing pruned-registration replacement path (passes on `main` and with this change).
- Full worker/scheduler/supervisor/process-recovery test files green on MySQL.
