### PR TITLE
Include the error in fail_many_claimed events and document recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Solid Queue can be used with SQL databases such as MySQL, PostgreSQL, or SQLite,
   - [Performance considerations](#performance-considerations)
 - [Failed jobs and retries](#failed-jobs-and-retries)
   - [Error reporting on jobs](#error-reporting-on-jobs)
+  - [Jobs interrupted by non-graceful process death](#jobs-interrupted-by-non-graceful-process-death)
 - [Puma plugin](#puma-plugin)
 - [Jobs and transactional integrity](#jobs-and-transactional-integrity)
 - [Recurring tasks](#recurring-tasks)
@@ -663,6 +664,27 @@ class ApplicationMailer < ActionMailer::Base
   end
 end
 ```
+
+### Jobs interrupted by non-graceful process death
+
+When a process dies without a clean shutdown (for example, `SIGKILL`ed by the OS or the container runtime because of memory limits), the jobs it was running can't be released back to their queues. Once another process notices the missing heartbeats and prunes the dead process's registration, its in-flight jobs are marked as failed with `SolidQueue::Processes::ProcessPrunedError`. Solid Queue deliberately doesn't retry these automatically: the job itself might be what's killing the process (for example, a job that exhausts the container's memory), and retrying it blindly would just kill the next worker too.
+
+If you know your jobs are idempotent and want to implement your own recovery policy, you can subscribe to the `fail_many_claimed.solid_queue` event, which includes the error and the affected job IDs in its payload:
+
+```ruby
+# config/initializers/solid_queue_recovery.rb
+ActiveSupport::Notifications.subscribe("fail_many_claimed.solid_queue") do |event|
+  if event.payload[:error].is_a?(SolidQueue::Processes::ProcessPrunedError)
+    SolidQueue::FailedExecution.where(job_id: event.payload[:job_ids]).each do |failed_execution|
+      # Apply your own safeguard against retrying the same job in a loop,
+      # e.g. a counter in the job's arguments or a cap stored elsewhere.
+      failed_execution.retry
+    end
+  end
+end
+```
+
+The event is emitted in the process that performs the pruning (or the supervisor when it reaps a crashed fork, with `SolidQueue::Processes::ProcessExitError`), so make sure the subscription is set up in an initializer, where all Solid Queue processes will load it.
 
 ## Puma plugin
 

--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -48,6 +48,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
           payload[:process_ids] = executions.map(&:process_id).uniq
           payload[:job_ids] = executions.map(&:job_id).uniq
           payload[:size] = executions.size
+          payload[:error] = error
         end
       end
     end

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -16,7 +16,10 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def fail_many_claimed(event)
-    warn formatted_event(event, action: "Fail claimed jobs", **event.payload.slice(:job_ids, :process_ids))
+    attributes = event.payload.slice(:job_ids, :process_ids)
+    attributes[:error] = formatted_error(event.payload[:error]) if event.payload[:error]
+
+    warn formatted_event(event, action: "Fail claimed jobs", **attributes)
   end
 
   def release_claimed(event)

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -164,6 +164,9 @@ class InstrumentationTest < ActiveSupport::TestCase
 
     assert_equal 1, events.count
     assert_event events.first, "fail_many_claimed", process_ids: [ process.id ], job_ids: jobs.map(&:id), size: 3
+
+    error = events.first.last[:error]
+    assert_instance_of SolidQueue::Processes::ProcessPrunedError, error
   end
 
   test "errors when deregistering processes are included in deregister_process events" do


### PR DESCRIPTION
Closes #591

### Approach

Following the discussion in #591: not automatic retries (poison-pill risk, as @rosa pointed out), but the hook @nhorton asked for, so applications that know their jobs are idempotent can implement their own recovery policy.

It turns out most of the machinery already exists: `ClaimedExecution.fail_all_with` — the path that marks in-flight jobs as failed when their process is pruned or a crashed fork is reaped — already emits `fail_many_claimed.solid_queue` with the affected `job_ids` and `process_ids`. What was missing was the `error` in the payload, so subscribers couldn't distinguish a prune (`ProcessPrunedError`) from other mass failures, and any documentation that this hook exists.

This PR:

- Adds `error` to the `fail_many_claimed` payload (and to its log line, using the existing `formatted_error` convention).
- Extends the existing instrumentation test to assert the error is included.
- Documents the recovery pattern in the README under "Failed jobs and retries": why these jobs aren't retried automatically, and a subscriber example that re-enqueues via `FailedExecution#retry` with an explicit note that the application must bring its own safeguard against retry loops.

No new machinery, no behavior change for anyone not subscribing to the event.

### Testing

Instrumentation and log subscriber test files green on MySQL.
