### PR TITLE
Replace terminated forks even if releasing their claimed jobs fails

### DIFF
--- a/lib/solid_queue/fork_supervisor.rb
+++ b/lib/solid_queue/fork_supervisor.rb
@@ -73,8 +73,16 @@ module SolidQueue
         if terminated_fork = process_instances.delete(pid)
           terminated_fork.mark_as_reaped
           payload[:fork] = terminated_fork
-          error = Processes::ProcessExitError.new(status)
-          release_claimed_jobs_by(terminated_fork, with_error: error)
+
+          begin
+            release_claimed_jobs_by(terminated_fork, with_error: Processes::ProcessExitError.new(status))
+          rescue StandardError => error
+            # The database may be unreachable — likely the same reason the fork
+            # terminated. Starting the replacement can't depend on it: the jobs
+            # claimed by the terminated fork will be failed when its stale
+            # registration is pruned once the database is back.
+            handle_thread_error(error)
+          end
 
           start_process(configured_processes.delete(pid))
         end

--- a/lib/solid_queue/fork_supervisor.rb
+++ b/lib/solid_queue/fork_supervisor.rb
@@ -57,8 +57,7 @@ module SolidQueue
           terminated_fork.mark_as_reaped
 
           if !status.exited? || status.exitstatus.to_i > 0
-            error = Processes::ProcessExitError.new(status)
-            release_claimed_jobs_by(terminated_fork, with_error: error)
+            attempt_to_release_claimed_jobs_by(terminated_fork, status)
           end
         end
 
@@ -74,19 +73,21 @@ module SolidQueue
           terminated_fork.mark_as_reaped
           payload[:fork] = terminated_fork
 
-          begin
-            release_claimed_jobs_by(terminated_fork, with_error: Processes::ProcessExitError.new(status))
-          rescue StandardError => error
-            # The database may be unreachable — likely the same reason the fork
-            # terminated. Starting the replacement can't depend on it: the jobs
-            # claimed by the terminated fork will be failed when its stale
-            # registration is pruned once the database is back.
-            handle_thread_error(error)
-          end
+          attempt_to_release_claimed_jobs_by(terminated_fork, status)
 
           start_process(configured_processes.delete(pid))
         end
       end
+    end
+
+    # The database may be unreachable — likely the same reason the fork
+    # terminated. Neither starting a replacement nor shutting down can depend
+    # on it: the jobs claimed by the terminated fork will be failed when its
+    # stale registration is pruned once the database is back.
+    def attempt_to_release_claimed_jobs_by(terminated_fork, status)
+      release_claimed_jobs_by(terminated_fork, with_error: Processes::ProcessExitError.new(status))
+    rescue StandardError => error
+      handle_thread_error(error)
     end
 
     def all_processes_terminated?

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -129,6 +129,29 @@ class ForkSupervisorTest < ActiveSupport::TestCase
     terminate_process(pid)
   end
 
+  test "replace a terminated fork even if releasing its claimed jobs fails" do
+    configuration = SolidQueue::Configuration.new(workers: [ { queues: "*", processes: 1 } ], dispatchers: [], skip_recurring: true)
+    supervisor = SolidQueue::ForkSupervisor.new(configuration)
+
+    configured_process = configuration.configured_processes.first
+    terminated_fork = stub(kind: "Worker", name: "worker-42", hostname: "localhost", mark_as_reaped: true)
+
+    supervisor.send(:process_instances)[42] = terminated_fork
+    supervisor.send(:configured_processes)[42] = configured_process
+
+    # The database is unreachable when the supervisor tries to fail the
+    # terminated fork's claimed jobs, like right after a database restart
+    # that also crashed the fork
+    supervisor.expects(:release_claimed_jobs_by).raises(ActiveRecord::ConnectionNotEstablished.new("connection is closed"))
+    supervisor.expects(:start_process).with(configured_process)
+
+    status = stub(exited?: true, exitstatus: 1, pid: 42, signaled?: false, stopsig: nil, termsig: nil)
+
+    assert_nothing_raised do
+      supervisor.send(:replace_fork, 42, status)
+    end
+  end
+
   test "fail orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
     process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")

--- a/test/unit/fork_supervisor_test.rb
+++ b/test/unit/fork_supervisor_test.rb
@@ -152,6 +152,28 @@ class ForkSupervisorTest < ActiveSupport::TestCase
     end
   end
 
+  test "reap a terminated fork on shutdown even if releasing its claimed jobs fails" do
+    configuration = SolidQueue::Configuration.new(workers: [ { queues: "*", processes: 1 } ], dispatchers: [], skip_recurring: true)
+    supervisor = SolidQueue::ForkSupervisor.new(configuration)
+
+    terminated_fork = stub(kind: "Worker", name: "worker-42", hostname: "localhost", mark_as_reaped: true)
+    supervisor.send(:process_instances)[42] = terminated_fork
+    supervisor.send(:configured_processes)[42] = configuration.configured_processes.first
+
+    # The fork was killed and the database is unreachable when the supervisor
+    # reaps it during shutdown
+    status = stub(exited?: false, exitstatus: nil, pid: 42, signaled?: true, stopsig: nil, termsig: 9)
+    ::Process.stubs(:waitpid2).returns([ 42, status ]).then.returns(nil)
+    supervisor.expects(:release_claimed_jobs_by).raises(ActiveRecord::ConnectionNotEstablished.new("connection is closed"))
+
+    assert_nothing_raised do
+      supervisor.send(:reap_terminated_forks)
+    end
+
+    assert_empty supervisor.send(:process_instances)
+    assert_empty supervisor.send(:configured_processes)
+  end
+
   test "fail orphaned executions" do
     3.times { |i| StoreResultJob.set(queue: :new_queue).perform_later(i) }
     process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")


### PR DESCRIPTION
Fixes #683

### Problem

When the database restarts under a running fork supervisor, the workers and dispatcher crash and exit (their polling loops raise). The supervisor reaps them and calls `replace_fork`, which runs `release_claimed_jobs_by` — a database call — *before* starting the replacement. With the database still down, that call raises, the exception escapes `check_and_replace_terminated_processes`, and the whole `supervise` loop crashes without ever replacing the terminated forks.

The scheduler, whose per-task enqueue errors are reported without killing the process, survives and reconnects — so after the database comes back, recurring jobs keep being enqueued with no workers left to run them. I reproduced this end-to-end on `main` with `docker compose restart mysql` under `bin/jobs`: a growing backlog of ready executions, worker heartbeats frozen at the restart timestamp, and a supervisor that never recovers. Full chain of evidence — including the recovered crash backtrace and why the process hangs instead of exiting when the `debug` gem is loaded — is written up in a comment on #683.

### Fix

Rescue errors from `release_claimed_jobs_by` in `replace_fork`, report them through `handle_thread_error`, and start the replacement regardless. The database being unreachable at that moment is likely the very reason the fork died, so the replacement can't depend on it.

The terminated fork's claimed jobs aren't lost by skipping the release: its stale process registration is pruned once the database is reachable again, and pruning fails its claimed executions through the normal `ProcessPrunedError` path.

### Testing

- New unit test: `replace_fork` still starts the replacement when releasing claimed jobs raises `ConnectionNotEstablished` (errors without this change, passes with it).
- Live verification of the original scenario: with this change, `bin/jobs` under a `docker compose restart mysql` recovers by itself — replacement workers crash-loop through the boot-timeout path while the database is down, then re-register and drain the backlog as soon as it's back. On `main`, the same scenario ends with a permanently dead supervisor loop and an ever-growing backlog.
