### PR TITLE
Destroy orphan BlockedExecution rows when the job class no longer resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,8 @@ It's important to note that after one or more candidate jobs are unblocked (eith
 
 When using `discard` as the behaviour to handle conflicts, you might have jobs discarded for until the `duration` interval if something happens and a running job fails to release the semaphore.
 
+If a job's class no longer exists by the time its concurrency controls are checked—say it was renamed or removed in a deploy while jobs referencing it were still in the queue—the job is marked as failed with a `SolidQueue::Job::ClassMissingError`, so it shows up in [failed jobs](#failed-jobs-and-retries), where it can be retried once the class is back, or discarded. Jobs with a missing class picked up by a worker fail with the same error.
+
 
 For example:
 ```ruby

--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -2,6 +2,8 @@
 
 module SolidQueue
   class BlockedExecution < Execution
+    class JobClassMissingError < RuntimeError; end
+
     assumes_attributes_from_job :concurrency_key
     before_create :set_expires_at
 
@@ -48,9 +50,12 @@ module SolidQueue
         transaction do
           if job.job_class.nil?
             # The job's class no longer resolves (renamed/removed between deploys).
-            # Destroy the orphan row so the dispatcher stops retrying it forever.
+            # Mark the job as failed so it surfaces in Mission Control (where it can
+            # be retried once the class is restored, or discarded), and destroy the
+            # orphan row so the dispatcher stops retrying it forever.
+            job.failed_with(JobClassMissingError.new("Job class #{job.class_name.inspect} could not be resolved"))
             destroy!
-            payload[:orphaned] = true
+            payload[:failed] = true
           elsif acquire_concurrency_lock
             promote_to_ready
             destroy!

--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -46,7 +46,12 @@ module SolidQueue
     def release
       SolidQueue.instrument(:release_blocked, job_id: job.id, concurrency_key: concurrency_key, released: false) do |payload|
         transaction do
-          if acquire_concurrency_lock
+          if job.job_class.nil?
+            # The job's class no longer resolves (renamed/removed between deploys).
+            # Destroy the orphan row so the dispatcher stops retrying it forever.
+            destroy!
+            payload[:orphaned] = true
+          elsif acquire_concurrency_lock
             promote_to_ready
             destroy!
 
@@ -58,7 +63,8 @@ module SolidQueue
 
     private
       def set_expires_at
-        self.expires_at = job.concurrency_duration.from_now
+        duration = job.job_class ? job.concurrency_duration : SolidQueue.default_concurrency_control_period
+        self.expires_at = duration.from_now
       end
 
       def acquire_concurrency_lock

--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -2,8 +2,6 @@
 
 module SolidQueue
   class BlockedExecution < Execution
-    class JobClassMissingError < RuntimeError; end
-
     assumes_attributes_from_job :concurrency_key
     before_create :set_expires_at
 
@@ -49,12 +47,9 @@ module SolidQueue
       SolidQueue.instrument(:release_blocked, job_id: job.id, concurrency_key: concurrency_key, released: false) do |payload|
         transaction do
           if job.job_class.nil?
-            # The job's class no longer resolves (renamed/removed between deploys).
-            # Mark the job as failed so it surfaces in Mission Control (where it can
-            # be retried once the class is restored, or discarded), and destroy the
-            # orphan row so the dispatcher stops retrying it forever.
-            job.failed_with(JobClassMissingError.new("Job class #{job.class_name.inspect} could not be resolved"))
+            job.failed_with(Job::ClassMissingError.for(job))
             destroy!
+
             payload[:failed] = true
           elsif acquire_concurrency_lock
             promote_to_ready

--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -115,6 +115,8 @@ module SolidQueue
       end
 
       def execute
+        raise Job::ClassMissingError.for(job) if job.job_class.nil?
+
         ActiveJob::Base.execute(job.arguments.merge("provider_job_id" => job.id))
         Result.new(true, nil)
       rescue Exception => e

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -4,6 +4,15 @@ module SolidQueue
   class Job < Record
     class EnqueueError < StandardError; end
 
+    # Raised when a job's class can't be resolved anymore, typically because it
+    # was renamed or removed in a deploy while jobs referencing it were in
+    # flight. It subclasses NameError, which is what resolving the class raises.
+    class ClassMissingError < NameError
+      def self.for(job)
+        new("Job class #{job.class_name.inspect} could not be resolved")
+      end
+    end
+
     include Executable, Clearable, Recurrable, Batchable
 
     serialize :arguments, coder: JSON

--- a/app/models/solid_queue/job/concurrency_controls.rb
+++ b/app/models/solid_queue/job/concurrency_controls.rb
@@ -33,6 +33,10 @@ module SolidQueue
         blocked_execution.present?
       end
 
+      def job_class
+        @job_class ||= class_name.safe_constantize
+      end
+
       private
         def concurrency_on_conflict
           job_class.concurrency_on_conflict.to_s.inquiry
@@ -64,10 +68,6 @@ module SolidQueue
 
         def release_next_blocked_job
           BlockedExecution.release_one(concurrency_key)
-        end
-
-        def job_class
-          @job_class ||= class_name.safe_constantize
         end
 
         def execution

--- a/lib/solid_queue/log_subscriber.rb
+++ b/lib/solid_queue/log_subscriber.rb
@@ -59,7 +59,7 @@ class SolidQueue::LogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def release_blocked(event)
-    debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
+    debug formatted_event(event, action: "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released, :failed))
   end
 
   def enqueue_recurring_task(event)

--- a/test/models/solid_queue/blocked_execution_test.rb
+++ b/test/models/solid_queue/blocked_execution_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  class NonOverlappingJob < ApplicationJob
+    limits_concurrency key: ->(job_result, **) { job_result }
+
+    def perform(job_result)
+    end
+  end
+
+  setup do
+    @result = JobResult.create!(queue_name: "default")
+  end
+
+  teardown do
+    SolidQueue::Job.destroy_all
+    SolidQueue::Semaphore.delete_all
+    JobResult.delete_all
+  end
+
+  test "release destroys the blocked row when the job class no longer resolves" do
+    # Enqueue and consume the semaphore so the next job blocks.
+    NonOverlappingJob.perform_later(@result)
+    blocking_job = SolidQueue::Job.last
+    NonOverlappingJob.perform_later(@result)
+    blocked_job = SolidQueue::Job.last
+    blocked = blocked_job.blocked_execution
+    assert blocked, "expected the second job to be blocked"
+
+    # Simulate the class being renamed/removed between deploys
+    blocked_job.update_columns(class_name: "GoneJob")
+
+    assert_difference -> { SolidQueue::BlockedExecution.count }, -1 do
+      assert_nothing_raised do
+        blocked.reload.release
+      end
+    end
+
+    # No ready execution was promoted — the orphan row was just cleaned up.
+    assert_nil SolidQueue::ReadyExecution.find_by(job_id: blocked_job.id)
+  end
+end

--- a/test/models/solid_queue/blocked_execution_test.rb
+++ b/test/models/solid_queue/blocked_execution_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
@@ -44,7 +46,7 @@ class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
 
     failed = SolidQueue::FailedExecution.find_by(job_id: blocked_job.id)
     assert failed, "expected a failed execution to be created for the orphan"
-    assert_equal "SolidQueue::BlockedExecution::JobClassMissingError", failed.exception_class
+    assert_equal "SolidQueue::Job::ClassMissingError", failed.exception_class
     assert_match "GoneJob", failed.message
   end
 end

--- a/test/models/solid_queue/blocked_execution_test.rb
+++ b/test/models/solid_queue/blocked_execution_test.rb
@@ -20,7 +20,7 @@ class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
     JobResult.delete_all
   end
 
-  test "release destroys the blocked row when the job class no longer resolves" do
+  test "release marks the job as failed and destroys the blocked row when the job class no longer resolves" do
     # Enqueue and consume the semaphore so the next job blocks.
     NonOverlappingJob.perform_later(@result)
     blocking_job = SolidQueue::Job.last
@@ -32,13 +32,19 @@ class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
     # Simulate the class being renamed/removed between deploys
     blocked_job.update_columns(class_name: "GoneJob")
 
-    assert_difference -> { SolidQueue::BlockedExecution.count }, -1 do
+    assert_difference -> { SolidQueue::BlockedExecution.count } => -1,
+                     -> { SolidQueue::FailedExecution.count } => 1 do
       assert_nothing_raised do
         blocked.reload.release
       end
     end
 
-    # No ready execution was promoted — the orphan row was just cleaned up.
+    # No ready execution was promoted — the orphan is now surfaced as a failed execution.
     assert_nil SolidQueue::ReadyExecution.find_by(job_id: blocked_job.id)
+
+    failed = SolidQueue::FailedExecution.find_by(job_id: blocked_job.id)
+    assert failed, "expected a failed execution to be created for the orphan"
+    assert_equal "SolidQueue::BlockedExecution::JobClassMissingError", failed.exception_class
+    assert_match "GoneJob", failed.message
   end
 end

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -146,7 +146,7 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
     claimed_execution = claim_job(job)
 
     assert_difference -> { SolidQueue::ClaimedExecution.count } => -1, -> { SolidQueue::FailedExecution.count } => 1 do
-      assert_raises NameError do
+      assert_raises SolidQueue::Job::ClassMissingError do
         claimed_execution.perform
       end
     end
@@ -159,7 +159,7 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
     claimed_execution = claim_job(job)
 
     assert_difference -> { SolidQueue::ClaimedExecution.count } => -1, -> { SolidQueue::FailedExecution.count } => 1 do
-      assert_raises NameError do
+      assert_raises SolidQueue::Job::ClassMissingError do
         claimed_execution.perform
       end
     end


### PR DESCRIPTION
Fixes #784.

## Summary

Fixes a `DelegationError` raised on every `SolidQueue::Dispatcher::ConcurrencyMaintenance` tick when a `BlockedExecution` row references a `Job` whose `class_name` no longer `safe_constantize`s — e.g. because the concurrency-limited ActiveJob class was renamed or removed between deploys.

`Job#acquire_concurrency_lock` already gates on `concurrency_limited?` (which checks `job_class.present?`), but `BlockedExecution#acquire_concurrency_lock` — invoked from the dispatcher-driven release path — went straight to `Semaphore.wait(job)`, which calls `job.concurrency_limit`, which is delegated to a `nil` `job_class`:

```
ActiveSupport::DelegationError: concurrency_limit delegated to job_class, but job_class is nil
  app/models/solid_queue/job/concurrency_controls.rb:11:in 'concurrency_limit'
  app/models/solid_queue/semaphore.rb:86:in 'limit'
  app/models/solid_queue/semaphore.rb:58:in 'attempt_creation'
  app/models/solid_queue/semaphore.rb:46:in 'wait'
  app/models/solid_queue/blocked_execution.rb:65:in 'acquire_concurrency_lock'
  app/models/solid_queue/blocked_execution.rb:49:in 'block (2 levels) in release'
  ...
  lib/solid_queue/dispatcher/concurrency_maintenance.rb:40
```

Because the exception is raised inside `BlockedExecution#release`'s transaction, the row is never destroyed or promoted, and the dispatcher re-picks the same orphans forever — flooding error reporters and starving any legitimately blocked jobs that share the concurrency key.

## Changes

- `BlockedExecution#release`: if `job.job_class` is `nil`, destroy the orphan row and emit `orphaned: true` in the `release_blocked` instrumentation payload. Otherwise fall through to the existing acquire/promote/destroy path.
- `BlockedExecution#set_expires_at`: fall back to `SolidQueue.default_concurrency_control_period` when the class does not resolve (guards the same latent bug at create time).
- `Job#job_class` promoted from private to public so `BlockedExecution` can consult it.
- New unit test covering the orphan release path.

## Test plan

- [x] `bin/rails test test/models/solid_queue/blocked_execution_test.rb` — new test passes.
- [x] `bin/rails test test/models/` — full model suite green (97 runs, 585 assertions, 0 failures).
- [x] CI across mysql/postgres/sqlite.
