### PR TITLE
Release blocked executions whose job class no longer resolves

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -62,6 +62,11 @@ module SolidQueue
       end
 
       def acquire_concurrency_lock
+        # A job whose class no longer resolves can't check its concurrency limits, but it
+        # can't hold a semaphore either. Release it without one so it fails on execution
+        # instead of crashing the dispatcher's concurrency maintenance forever.
+        return true unless job.concurrency_limited?
+
         Semaphore.wait(job)
       end
 

--- a/test/models/solid_queue/blocked_execution_test.rb
+++ b/test/models/solid_queue/blocked_execution_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SolidQueue::BlockedExecutionTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  class NonOverlappingJob < ApplicationJob
+    limits_concurrency key: ->(job_result, **) { job_result }
+
+    def perform(job_result)
+    end
+  end
+
+  setup do
+    @result = JobResult.create!(queue_name: "default")
+  end
+
+  test "release a blocked execution whose job class no longer resolves" do
+    NonOverlappingJob.perform_later(@result)
+    NonOverlappingJob.perform_later(@result)
+
+    blocked_job = SolidQueue::Job.last
+    assert blocked_job.blocked?
+
+    # Simulate the job class being renamed or deleted in a later deploy
+    SolidQueue::Job.where(id: blocked_job.id).update_all(class_name: "NoLongerExistingJob")
+    semaphore_value = SolidQueue::Semaphore.find_by!(key: blocked_job.concurrency_key).value
+
+    assert SolidQueue::BlockedExecution.release_one(blocked_job.concurrency_key)
+
+    # The execution is promoted to ready, where it will fail on execution and
+    # be recorded as failed, instead of being retried by the dispatcher forever
+    assert_not SolidQueue::BlockedExecution.exists?(job_id: blocked_job.id)
+    assert SolidQueue::ReadyExecution.exists?(job_id: blocked_job.id)
+
+    # Without concurrency limits to check, no semaphore slot is taken
+    assert_equal semaphore_value, SolidQueue::Semaphore.find_by!(key: blocked_job.concurrency_key).value
+  end
+end


### PR DESCRIPTION
Fixes #784

### Problem

When a `SolidQueue::BlockedExecution` row exists for a job whose `class_name` no longer `safe_constantize`s (class renamed, removed, or re-namespaced between deploys), the dispatcher's concurrency maintenance crashes on every tick, forever:

```
ActiveSupport::DelegationError: concurrency_limit delegated to job_class, but job_class is nil
```

`BlockedExecution#release` calls `Semaphore.wait(job)` unconditionally, and `Semaphore::Proxy#limit`/`#expires_at` dereference `job.concurrency_limit`/`job.concurrency_duration`, which are delegated to `job_class` — `nil` in this scenario. The release transaction rolls back, so `unblock_blocked_executions` picks up the same row again on the next tick and the orphan is never released or cleaned up.

### Fix

`Job#concurrency_limited?` already treats jobs without a resolvable class as not concurrency-limited, and `Job#acquire_concurrency_lock` consults it before touching the semaphore — the blocked execution release path was the only one that didn't. This applies the same guard there: the execution is promoted to ready without taking a semaphore slot, so the job fails on execution with a proper `NameError` and shows up as a failed execution (visible, retriable, discardable), instead of wedging the dispatcher indefinitely.

### Test

The regression test reproduces the exact `DelegationError` from the issue on `main` and passes with the fix. It also asserts the semaphore value is untouched by the release, since there are no concurrency limits left to enforce for a class that is gone.