### PR TITLE
Assert the successful job's output regardless of execution order

### DIFF
--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -176,7 +176,7 @@ class WorkerTest < ActiveSupport::TestCase
     @worker.wake_up
 
     assert_not @worker.pool.shutdown?
-    assert_equal "ok", JobBuffer.last_value
+    assert_includes JobBuffer.values, "ok"
     assert_equal 0, SolidQueue::ClaimedExecution.count
   end
 


### PR DESCRIPTION
`WorkerTest#test_worker_keeps_running_after_a_regular_job_failure` (added in #768) has been the most frequent CI failure on main since it landed: 4 of 5 failed jobs in [the #795 merge run](https://github.com/rails/solid_queue/actions/runs/33264397491) and 3 in [its own merge run](https://github.com/rails/solid_queue/actions/runs/32651183113).

It's an ordering assumption in the test, not a bug in the code: `RaisingJob` also writes to `JobBuffer` when it raises, and both jobs run concurrently in the worker's pool, so `JobBuffer.last_value` is whichever job finished last. The test is about the worker surviving the failure and the successful job getting through, so assert that "ok" is in the buffer rather than last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACej2M9mLVDwpE3Bk8V41