### PR TITLE
Harden the lifecycle and pool-size worker tests against slow databases

### DIFF
--- a/test/integration/async_processes_lifecycle_test.rb
+++ b/test/integration/async_processes_lifecycle_test.rb
@@ -96,7 +96,12 @@ class AsyncProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 0.2.seconds)
 
-    signal_process(@pid, :TERM, wait: 0.3.second)
+    # Wait for the "pause" job to start, which means both jobs have been
+    # claimed, before sending TERM, so the worker finishes them while
+    # shutting down instead of stopping before it gets to claim them
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
+
+    signal_process(@pid, :TERM, wait: 0.1.second)
     wait_for_jobs_to_finish_for(3.seconds)
 
     assert_completed_job_results("no pause")
@@ -113,7 +118,12 @@ class AsyncProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 0.2.seconds)
 
-    signal_process(@pid, :INT, wait: 0.3.second)
+    # Wait for the "pause" job to start, which means both jobs have been
+    # claimed, before sending INT, so the worker finishes them while
+    # shutting down instead of stopping before it gets to claim them
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
+
+    signal_process(@pid, :INT, wait: 0.1.second)
     wait_for_jobs_to_finish_for(2.second)
 
     assert_completed_job_results("no pause")

--- a/test/integration/fiber_processes_lifecycle_test.rb
+++ b/test/integration/fiber_processes_lifecycle_test.rb
@@ -38,7 +38,12 @@ class FiberProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 1.second)
 
-    signal_process(@pid, :TERM, wait: 0.3.second)
+    # Wait for the "pause" job to start, which means both jobs have been
+    # claimed, before sending TERM, so the worker finishes them while
+    # shutting down instead of stopping before it gets to claim them
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
+
+    signal_process(@pid, :TERM, wait: 0.1.second)
     wait_for_jobs_to_finish_for(3.seconds)
 
     assert_completed_job_results("no pause")
@@ -53,13 +58,15 @@ class FiberProcessesLifecycleTest < ActiveSupport::TestCase
 
   test "quit supervisor while there are jobs in-flight" do
     no_pause = enqueue_store_result_job("no pause")
-    # long enough pause to make sure it doesn't finish
-    pause = enqueue_store_result_job("pause", pause: 60.second)
+    # long enough pause to make sure it doesn't finish before QUIT arrives
+    pause = enqueue_store_result_job("pause", pause: 60.seconds)
 
-    wait_while_with_timeout(1.second) { SolidQueue::ReadyExecution.count > 0 }
+    # Wait for the "no pause" job to finish and the "pause" job to start
+    # before sending QUIT, so it always arrives while "pause" is in-flight
+    wait_for_jobs_to_finish_for(3.seconds, except: pause)
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
 
-    signal_process(@pid, :QUIT, wait: 0.4.second)
-    wait_for_jobs_to_finish_for(2.seconds, except: pause)
+    signal_process(@pid, :QUIT, wait: 0.1.second)
 
     wait_while_with_timeout(2.seconds) { process_exists?(@pid) }
     assert_not process_exists?(@pid)

--- a/test/integration/forked_processes_lifecycle_test.rb
+++ b/test/integration/forked_processes_lifecycle_test.rb
@@ -92,7 +92,12 @@ class ForkedProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 1.second)
 
-    signal_process(@pid, :TERM, wait: 0.3.second)
+    # Wait for the "pause" job to start, which means both jobs have been
+    # claimed, before sending TERM, so the worker finishes them while
+    # shutting down instead of stopping before it gets to claim them
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
+
+    signal_process(@pid, :TERM, wait: 0.1.second)
     wait_for_jobs_to_finish_for(3.seconds)
 
     assert_completed_job_results("no pause")
@@ -109,7 +114,12 @@ class ForkedProcessesLifecycleTest < ActiveSupport::TestCase
     no_pause = enqueue_store_result_job("no pause")
     pause = enqueue_store_result_job("pause", pause: 1.second)
 
-    signal_process(@pid, :INT, wait: 0.3.second)
+    # Wait for the "pause" job to start, which means both jobs have been
+    # claimed, before sending INT, so the worker finishes them while
+    # shutting down instead of stopping before it gets to claim them
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "pause") }
+
+    signal_process(@pid, :INT, wait: 0.1.second)
     wait_for_jobs_to_finish_for(3.second)
 
     assert_completed_job_results("no pause")

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -56,7 +56,7 @@ class WorkerTest < ActiveSupport::TestCase
 
         worker.start
 
-        wait_for_jobs_to_finish_for(2.second)
+        wait_for_jobs_to_finish_for(5.seconds)
         worker.wake_up
 
         assert_equal 5, JobResult.where(queue_name: :background, status: "completed", value: :paused).count


### PR DESCRIPTION
Fixes items 2 and 3 of #797 (the `WorkerTest` pool-size test in thread and fiber mode, and the fiber lifecycle `quit`/`term` tests), which together account for most of the non-Rails-7.1 flakes in the catalogue.

**How they were reproduced.** None of them fail locally in 20+ runs, so I throttled the database container to 8% of a CPU (`docker update --cpus=0.08`) to imitate a slow CI runner:

- The fiber `quit` test failed **4 of 8** runs against throttled PostgreSQL, with exactly the two CI signatures ("no pause" job not completed; supervisor still alive 2 s after QUIT). The forked twin, hardened in 0a7c1cf, passed 4 of 4 under the same conditions.
- The pool-size worker test's eight jobs take ~0.33 s normally but 1.4–2.7 s against throttled MySQL: a steady trickle that overruns the fixed 2-second wait, matching the CI failures (6 of 8 jobs done in thread mode, 3 of 8 in fiber mode). Not a lost wake-up: every `restore_capacity` notifies, and a self-pipe byte written before the sleep makes it return immediately.

**Changes.**
- Port 0a7c1cf's deterministic waits into the fiber `quit` test (its file was copied from the forked tests before that landed).
- In the `term` and `int` tests of all three lifecycle suites, wait for the "pause" job to have started (so both jobs are claimed) before sending the signal, instead of a fixed 0.3 s delay after enqueuing.
- Give the pool-size worker test the 5-second budget most of the suite already uses.

**Verification with the fix**, against the same throttled databases: fiber lifecycle 8/8, forked `term`/`quit`/`int` 3/3 + 3/3, async `term`/`quit`/`int` 3/3 + 3/3, pool-size worker test 6/6 on MySQL; and all touched files green unthrottled on sqlite, MySQL and PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACej2M9mLVDwpE3Bk8V41