### PR TITLE
Detect subclasses of the Solid Queue adapter

### DIFF
--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -142,7 +142,7 @@ module SolidQueue
       end
 
       def using_solid_queue_adapter?
-        job_class.queue_adapter_name.inquiry.solid_queue?
+        job_class.queue_adapter.is_a?(ActiveJob::QueueAdapters::SolidQueueAdapter)
       end
 
       def enqueue_and_record(run_at:)

--- a/lib/active_job/batch_id.rb
+++ b/lib/active_job/batch_id.rb
@@ -51,7 +51,7 @@ module ActiveJob
     private
 
       def solid_queue_job?
-        self.class.queue_adapter_name == "solid_queue"
+        self.class.queue_adapter.is_a?(ActiveJob::QueueAdapters::SolidQueueAdapter)
       end
   end
 end

--- a/test/models/solid_queue/batch_test.rb
+++ b/test/models/solid_queue/batch_test.rb
@@ -147,6 +147,14 @@ class SolidQueue::BatchTest < ActiveSupport::TestCase
     def perform; end
   end
 
+  class SubclassedSolidQueueAdapter < ActiveJob::QueueAdapters::SolidQueueAdapter; end
+
+  class SubclassedAdapterJob < ApplicationJob
+    self.queue_adapter = SubclassedSolidQueueAdapter.new
+
+    def perform; end
+  end
+
   class HookedCallbackJob < ApplicationJob
     cattr_accessor :enqueue_hook_ran, default: false
 
@@ -179,6 +187,13 @@ class SolidQueue::BatchTest < ActiveSupport::TestCase
 
     assert batch.reload.finished?
     assert_equal 0, SolidQueue::Job.where(class_name: AbortingCallbackJob.name).count
+  end
+
+  test "jobs using a subclass of the Solid Queue adapter belong to the batch" do
+    batch = SolidQueue::Batch.enqueue { SubclassedAdapterJob.perform_later }
+
+    assert_equal 1, batch.jobs.count
+    assert_equal batch.id, SolidQueue::Job.where(class_name: SubclassedAdapterJob.name).sole.batch_id
   end
 
   test "callback jobs enqueue through solid_queue regardless of their class adapter" do

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -41,6 +41,16 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     end
   end
 
+  class SubclassedSolidQueueAdapter < ActiveJob::QueueAdapters::SolidQueueAdapter; end
+
+  class JobUsingSubclassedSolidQueueAdapter < ApplicationJob
+    self.queue_adapter = SubclassedSolidQueueAdapter.new
+
+    def perform
+      JobBuffer.add "job_using_subclassed_solid_queue_adapter"
+    end
+  end
+
   class JobWithConcurrencyControlsAndDiscard < ApplicationJob
     limits_concurrency key: -> { true }, on_conflict: :discard
 
@@ -85,6 +95,14 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     wait_while_with_timeout!(0.5.seconds) { JobBuffer.size == previous_size }
 
     assert_equal "job_using_async_adapter", JobBuffer.last_value
+  end
+
+  test "job using a subclass of the Solid Queue adapter" do
+    task = recurring_task_with(class_name: "JobUsingSubclassedSolidQueueAdapter")
+
+    assert_difference -> { SolidQueue::RecurringExecution.count }, +1 do
+      enqueue_and_assert_performed_with_result task, "job_using_subclassed_solid_queue_adapter"
+    end
   end
 
   test "error when enqueuing job before recording task" do


### PR DESCRIPTION
Fixes #489.

`RecurringTask#using_solid_queue_adapter?` compared the adapter's *name* to `"solid_queue"`, so a job class using a subclass of `ActiveJob::QueueAdapters::SolidQueueAdapter` (the reporter's case: picking a shard at enqueue time) was treated as a foreign adapter and its recurring runs were enqueued through `perform_later` without a `RecurringExecution` row. The batches code had copied the same comparison into `ActiveJob::BatchId#solid_queue_job?`, so such jobs never joined a batch either. Both now check the adapter's ancestry.

The constant is resolvable wherever the gem is loaded, even in a process that never configures the adapter: the gem's Zeitwerk loader registers it as an autoload on `ActiveJob::QueueAdapters` (verified in a bare Ruby process).

Two tests, one per site, with a named adapter subclass; both fail on main and pass with the fix. Changed files green on sqlite, MySQL and PostgreSQL; full sqlite suite green (357 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACej2M9mLVDwpE3Bk8V41