### PR TITLE
Keep the Puma plugin's shutdown going when its output is gone

### DIFF
--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -129,5 +129,8 @@ Puma::Plugin.create do
 
     def log(...)
       log_writer.log(...)
+    rescue Errno::EIO
+      # The controlling terminal can disappear before the monitor thread shuts
+      # down the child process. Keep shutdown moving even when logging cannot.
     end
 end

--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -129,8 +129,9 @@ Puma::Plugin.create do
 
     def log(...)
       log_writer.log(...)
-    rescue Errno::EIO
-      # The controlling terminal can disappear before the monitor thread shuts
-      # down the child process. Keep shutdown moving even when logging cannot.
+    rescue Errno::EIO, Errno::EPIPE, Errno::EBADF
+      # The controlling terminal can disappear, or the output pipe close, before
+      # the monitor thread shuts down the child process. Keep shutdown moving
+      # even when logging cannot.
     end
 end

--- a/test/unit/puma_plugin_test.rb
+++ b/test/unit/puma_plugin_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "puma/plugin/solid_queue"
+
+class PumaPluginTest < ActiveSupport::TestCase
+  class ClosedTerminalLogWriter
+    def log(...)
+      raise Errno::EIO
+    end
+  end
+
+  test "monitor still stops the process when shutdown logging fails" do
+    plugin = Puma::Plugins.find("solid_queue").new
+    plugin.instance_variable_set(:@log_writer, ClosedTerminalLogWriter.new)
+
+    plugin.stubs(:puma_dead?).returns(true)
+    Process.expects(:kill).with(:INT, Process.pid)
+
+    plugin.send(:monitor, :puma_dead?, "Detected Puma has gone away, stopping Solid Queue...")
+  end
+end

--- a/test/unit/puma_plugin_test.rb
+++ b/test/unit/puma_plugin_test.rb
@@ -4,19 +4,25 @@ require "test_helper"
 require "puma/plugin/solid_queue"
 
 class PumaPluginTest < ActiveSupport::TestCase
-  class ClosedTerminalLogWriter
+  class ClosedOutputLogWriter
+    def initialize(error)
+      @error = error
+    end
+
     def log(...)
-      raise Errno::EIO
+      raise @error
     end
   end
 
-  test "monitor still stops the process when shutdown logging fails" do
-    plugin = Puma::Plugins.find("solid_queue").new
-    plugin.instance_variable_set(:@log_writer, ClosedTerminalLogWriter.new)
+  [ Errno::EIO, Errno::EPIPE, Errno::EBADF ].each do |error|
+    test "monitor still stops the process when shutdown logging fails with #{error}" do
+      plugin = Puma::Plugins.find("solid_queue").new
+      plugin.instance_variable_set(:@log_writer, ClosedOutputLogWriter.new(error))
 
-    plugin.stubs(:puma_dead?).returns(true)
-    Process.expects(:kill).with(:INT, Process.pid)
+      plugin.stubs(:puma_dead?).returns(true)
+      Process.expects(:kill).with(:INT, Process.pid)
 
-    plugin.send(:monitor, :puma_dead?, "Detected Puma has gone away, stopping Solid Queue...")
+      plugin.send(:monitor, :puma_dead?, "Detected Puma has gone away, stopping Solid Queue...")
+    end
   end
 end


### PR DESCRIPTION
Fixes #737.

When the terminal that started Puma goes away, the plugin's monitor thread notices the parent change, then `log` raises `Errno::EIO` writing to the dead PTY before `Process.kill(:INT, $$)` runs, so the supervisor and its children outlive the terminal and keep the port. Rescuing the error in `log` lets the shutdown proceed.

The first commit is @afurm's fix from #741, cherry-picked as they wrote it (closed unmerged; thank you!), including the unit test that the monitor still sends INT when logging raises. The second broadens the rescue to `Errno::EPIPE` and `Errno::EBADF`, which are the same failure with stdout piped to a reader that exited or with the stream already closed, and covers all three in the test.

Verified: the new unit test and the Puma plugin integration tests pass on sqlite; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACej2M9mLVDwpE3Bk8V41