### PR TITLE
Exit forked processes immediately to avoid a SQLite mutex deadlock at exit

### DIFF
--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -33,6 +33,11 @@ Puma::Plugin.create do
           @solid_queue_pid = fork do
             Thread.new { monitor_puma }
             SolidQueue::Supervisor.start(mode: :fork)
+
+            # Same as Processes::Supervised#create_fork: skip at-exit
+            # finalization, which can deadlock on database handles when a
+            # thread was killed while inside a query
+            exit!(0)
           end
         end
 
@@ -43,6 +48,11 @@ Puma::Plugin.create do
           @solid_queue_pid = fork do
             Thread.new { monitor_puma }
             start_solid_queue(mode: :fork)
+
+            # Same as Processes::Supervised#create_fork: skip at-exit
+            # finalization, which can deadlock on database handles when a
+            # thread was killed while inside a query
+            exit!(0)
           end
         end
 

--- a/lib/solid_queue/processes/supervised.rb
+++ b/lib/solid_queue/processes/supervised.rb
@@ -29,6 +29,14 @@ module SolidQueue::Processes
         fork do
           register_signal_handlers
           block.call
+
+          # Exit skipping at-exit hooks and finalizers, like Puma's cluster
+          # workers do: Ruby would finalize every object still alive in the
+          # fork, including SQLite database handles whose mutex can be left
+          # locked when a thread is killed while waiting in SQLite's busy
+          # handler, deadlocking the exit. Everything the process needs to do
+          # on shutdown has already run by now.
+          exit!(0)
         end
       end
 

--- a/test/dummy/config/puma_async.rb
+++ b/test/dummy/config/puma_async.rb
@@ -13,10 +13,6 @@ threads min_threads_count, max_threads_count
 #
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch("PORT") { 3000 }
-
 # Specifies the `environment` that Puma will run in.
 #
 environment ENV.fetch("RAILS_ENV") { "development" }

--- a/test/dummy/config/puma_fork.rb
+++ b/test/dummy/config/puma_fork.rb
@@ -13,10 +13,6 @@ threads min_threads_count, max_threads_count
 #
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch("PORT") { 3000 }
-
 # Specifies the `environment` that Puma will run in.
 #
 environment ENV.fetch("RAILS_ENV") { "development" }

--- a/test/unit/supervised_test.rb
+++ b/test/unit/supervised_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SupervisedTest < ActiveSupport::TestCase
+  class FakeProcess
+    include SolidQueue::Processes::Supervised
+
+    def stop
+    end
+  end
+
+  test "forked processes exit immediately, without running inherited at-exit hooks" do
+    reader, writer = IO.pipe
+
+    pid = FakeProcess.new.send(:create_fork) do
+      at_exit { writer.write("at_exit ran") }
+      writer.write("block ran")
+    end
+
+    writer.close
+    _, status = Process.waitpid2(pid)
+
+    assert_equal 0, status.exitstatus
+    assert_equal "block ran", reader.read
+  ensure
+    reader.close
+  end
+end


### PR DESCRIPTION
Fixes the orphaned/zombie Solid Queue processes on SQLite: the long-standing Puma plugin hang, several of the sqlite-only oddities catalogued in #797 (the fiber `term` supervisor outliving its teardown, the first-test CI hangs), and the ~1-in-10 zombie scheduler left behind by the plugin's "supervisor dies" test.

**Root cause** (found via gdb on a live zombie, then reproduced deterministically): killing a Ruby thread while it waits in SQLite's **busy handler** leaks the connection mutex — the sqlite3 gem invokes the handler with a bare `rb_funcall`, so the kill unwinds through SQLite's C frames and `sqlite3_step` never releases the mutex. Ruby kills leftover threads at process exit (a heartbeat/maintenance timer mid-query, a pool thread past `shutdown_timeout`) and then finalizes every remaining object, so the exit deadlocks inside `sqlite3_close_v2`:

```
ruby_cleanup → rb_objspace_call_finalizer → rb_data_free → sqlite3_close_v2 → pthread_mutex_lock (never returns)
```

Rails' SQLite adapter uses a Ruby-level busy handler in every configuration except 7.x's plain `timeout:` (`retries:` on 7.x, `busy_handler_timeout` from 7.2), so this bites exactly when several processes contend on one database — which is what the integration tests do, and what a multi-process production deployment on SQLite does. Kill-a-thread-mid-wait reproduces the hang 2/2 in a 25-line script with no Rails involved; the control (no kill) exits cleanly 2/2. The gem-level bug is being reported upstream to sqlite3-ruby separately.

**The fix**: forked processes exit with `exit!(0)` once their block has completed — at-exit hooks and finalizers are skipped, exactly like Puma's cluster workers and our own QUIT handler. Shutdown work (deregistering, releasing claims, lifecycle hooks) has all run by then. An error raised out of the block still propagates and exits non-zero, unchanged. The Puma plugin's supervisor fork gets the same treatment, which is what lets Puma's `Process.wait` return on shutdown.

Second commit: the plugin test configs still set `port 3000`, so every test Puma bound the default port in addition to the dynamically allocated one from #733, colliding with anything else on :3000.

**Verification**: new unit test (fork exits with status 0 without running inherited `at_exit` hooks); full sqlite suite 356 green; forked/fiber/async lifecycle suites green (they assert the forks' exit statuses); Puma plugin tests green; the "supervisor dies" test run 15× leaves **0** Solid Queue processes behind (verified via `/proc` cmdline scan), vs ~1 in 10 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACej2M9mLVDwpE3Bk8V41